### PR TITLE
Use custom build of applicationinsights

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/martincostello/alexa-london-travel#readme",
   "dependencies": {
     "alexa-app": "4.0.0",
-    "applicationinsights": "0.19.0",
+    "applicationinsights": "martincostello/ApplicationInsights-node.js#eef81e409f61e87bfac68b92c646b743a274f8d5",
     "request": "2.79.0",
     "request-promise": "4.1.1",
     "sinon": "2.1.0",


### PR DESCRIPTION
Use custom build of the `applicationinsights` npm package that may fix the issue with submitting data to Application Insights from AWS lambda.
