### PR TITLE
Revert ZIP-based deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ branches:
     - master
     - deploy
 
-before_deploy:
-  - zip -r alexa-london-travel.zip .
-
 deploy:
   - provider: lambda
     function_name: "alexa-london-travel-dev"
@@ -26,7 +23,6 @@ deploy:
     runtime: "nodejs6.10"
     timeout: 10,
     handler_name: "handler"
-    zip: "alexa-london-travel.zip"
     access_key_id:
       secure: "aJjugFDE24Z5UB/3PEGJEOlmpLFTUEQvtrczJiRRVBd1cG535MVmSm2GlVzVk1J96yqoVc8VqSEgWcdqlMcU4jupd6BxxFYDZE8k8hEQ9KmIFqG+VdBqn6SskadDVi/sihDakMvGVLi9koVOPfbYPoxQn+YOh3Ohu9RFbGKlUaX1/7s29VoBsX/e2iWvJQDVGqMWMg1hMtf91diOuxLbiUgsZWHQppm34UiM2oJBFHLuCjvSbtJMWJxEEULou9dgip1bCj5IxrpIM68E3Mn9ttK4ZotyL3LsgJYHp9P6KapzytKSa5eBoSXhJZx1FWMBSBW258uOtByARQyKBKrPg+csS7H8kFLNnaWLQhJqQGjU9eex6eVRDdeTcp4z5yfeGG803CrvWGcyHXANI/s1H0ktdzNK4T/SWEDh4oTgZzjaJdF15Upgw2GczO5TeO+9kbqc8cBHPHZmWp6q+bb6svvlX+EU3brBCcCIHDkwAp4Yv4rT/41ZKh0aZJ61/1Ulkb/xDcZh30kV8gc3dqnF6L8fhDXIfL1wMvw88lItiHiADcaqVV2Bb4OT4vP+cuSx7Ys7e7eyJn2y4qMqeCiFaGKqqYTbPG1gXJCLIhlqwLYJsf3yweTar8qqnrMhSJ5D6lRp9Eh2xoAk60jIBJgCH/oRjp0aErxJ4/iwxZcNx0Q="
     secret_access_key:
@@ -40,7 +36,6 @@ deploy:
     runtime: "nodejs6.10"
     timeout: 10,
     handler_name: "handler"
-    zip: "alexa-london-travel.zip"
     access_key_id:
       secure: "aJjugFDE24Z5UB/3PEGJEOlmpLFTUEQvtrczJiRRVBd1cG535MVmSm2GlVzVk1J96yqoVc8VqSEgWcdqlMcU4jupd6BxxFYDZE8k8hEQ9KmIFqG+VdBqn6SskadDVi/sihDakMvGVLi9koVOPfbYPoxQn+YOh3Ohu9RFbGKlUaX1/7s29VoBsX/e2iWvJQDVGqMWMg1hMtf91diOuxLbiUgsZWHQppm34UiM2oJBFHLuCjvSbtJMWJxEEULou9dgip1bCj5IxrpIM68E3Mn9ttK4ZotyL3LsgJYHp9P6KapzytKSa5eBoSXhJZx1FWMBSBW258uOtByARQyKBKrPg+csS7H8kFLNnaWLQhJqQGjU9eex6eVRDdeTcp4z5yfeGG803CrvWGcyHXANI/s1H0ktdzNK4T/SWEDh4oTgZzjaJdF15Upgw2GczO5TeO+9kbqc8cBHPHZmWp6q+bb6svvlX+EU3brBCcCIHDkwAp4Yv4rT/41ZKh0aZJ61/1Ulkb/xDcZh30kV8gc3dqnF6L8fhDXIfL1wMvw88lItiHiADcaqVV2Bb4OT4vP+cuSx7Ys7e7eyJn2y4qMqeCiFaGKqqYTbPG1gXJCLIhlqwLYJsf3yweTar8qqnrMhSJ5D6lRp9Eh2xoAk60jIBJgCH/oRjp0aErxJ4/iwxZcNx0Q="
     secret_access_key:


### PR DESCRIPTION
Revert #47 to see if applicationinsights 1.0.0 has fixed the dependency issue that originally caused it to break, and use the default Travis lambda deployment instead of zipping it.

Trying to diagnose #45 once #57 was deployed, this was found in the logs:

```
ApplicationInsights:unable to read app version:  [ { Error: Cannot find module '../../../package.json'
      at Error.AppInsightsAsyncCorrelatedErrorWrapper (/var/task/node_modules/applicationinsights/out/AutoCollection/CorrelationContextManager.js:172:18)
      at Function.Module._resolveFilename (module.js:469:15)
      at Function.Module._load (module.js:417:25)
      at Module.require (module.js:497:17)
      at Module.patchedRequire [as require] (/var/task/node_modules/diagnostic-channel/dist/src/patchRequire.js:14:46)
      at require (internal/module.js:20:19)
      at Context._loadApplicationContext (/var/task/node_modules/applicationinsights/out/Library/Context.js:18:31)
      at new Context (/var/task/node_modules/applicationinsights/out/Library/Context.js:9:14)
      at NodeClient.TelemetryClient (/var/task/node_modules/applicationinsights/out/Library/TelemetryClient.js:26:24)
      at new NodeClient (/var/task/node_modules/applicationinsights/out/Library/NodeClient.js:25:42)
      at Object.telemetry.createClient (/var/task/src/telemetry.js:19:10)
      at Object.telemetry.trackEvent (/var/task/src/telemetry.js:37:17)
      at onLaunch [as launchFunc] (/var/task/src/skill.js:50:15)
      at /var/task/node_modules/alexa-app/index.js:545:41
      at tryCatcher (/var/task/node_modules/bluebird/js/main/util.js:26:23)
      at Promise._settlePromiseFromHandler (/var/task/node_modules/bluebird/js/main/promise.js:510:31)
      at Promise._settlePromiseAt (/var/task/node_modules/bluebird/js/main/promise.js:584:18)
      at Promise._settlePromises (/var/task/node_modules/bluebird/js/main/promise.js:700:14)
      at Async._drainQueue (/var/task/node_modules/bluebird/js/main/async.js:123:16)
      at Async._drainQueues (/var/task/node_modules/bluebird/js/main/async.js:133:10)
      at Immediate.Async.drainQueues (/var/task/node_modules/bluebird/js/main/async.js:15:14)
      at runCallback (timers.js:672:20)
      at tryOnImmediate (timers.js:645:5)
      at processImmediate [as _immediateCallback] (timers.js:617:5) code: 'MODULE_NOT_FOUND' } ]
```
 Maybe `package.json` isn't being uploaded anymore and that's causing `applicationinsights` to break?