### PR TITLE
Disable telemetry batching

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -16,7 +16,9 @@ const telemetry = {
 telemetry.instrumentationKey = "";
 
 telemetry.createClient = function () {
-  return new appInsights.TelemetryClient(telemetry.instrumentationKey);
+  var client = new appInsights.TelemetryClient(telemetry.instrumentationKey);
+  client.config.maxBatchIntervalMs = 0;
+  return client;
 };
 
 /**

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -95,6 +95,8 @@ describe("Telemetry", function () {
       beforeEach(function () {
 
         client = {
+          config: {
+          },
           trackEvent: function () {
           },
           trackException: function () {


### PR DESCRIPTION
Disable batching of ApplicationInsights telemetry to see if it stops the function invocations hanging for #45.
