### PR TITLE
Set ApplicationInsights batch size to 1

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -17,7 +17,12 @@ telemetry.instrumentationKey = "";
 
 telemetry.createClient = function () {
   var client = new appInsights.TelemetryClient(telemetry.instrumentationKey);
+
+  // Prevent Lambda function from hanging and timing out.
+  // See https://github.com/martincostello/alexa-london-travel/issues/45.
   client.config.maxBatchIntervalMs = 0;
+  client.config.maxBatchSize = 1;
+
   return client;
 };
 


### PR DESCRIPTION
Set the batch size for ApplicationInsights to 1 to try and prevent [`setTimeout()` ever being called](https://github.com/Microsoft/ApplicationInsights-node.js/blob/05b70a06d47f5ee2ee72ca8d8a6d340eb7915de6/Library/Channel.ts#L61-L74) and causing the lambda function to timeout from hanging while waiting for metrics to send.

Relates to #45.