### PR TITLE
Disable disk retry caching

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -35,7 +35,9 @@ telemetry.setup = function (instrumentationKey) {
 
     telemetry.instrumentationKey = instrumentationKey;
 
-    telemetry.appInsights.setup(instrumentationKey).start();
+    telemetry.appInsights.setup(instrumentationKey)
+      .setUseDiskRetryCaching(false)
+      .start();
 
     telemetry.trackEvent = function (name, properties) {
       telemetry.createClient().trackEvent({

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -50,6 +50,10 @@ describe("Telemetry", function () {
       config = {
       };
 
+      config.setUseDiskRetryCaching = function () {
+        return config;
+      };
+
       config.start = function () {
         return config;
       };


### PR DESCRIPTION
Set `setUseDiskRetryCaching()` to `false` to try and [prevent a `setTimeout()` being queued up](https://github.com/Microsoft/ApplicationInsights-node.js/blob/3719ab34a2d59d4c08e41f0c74bea69c0619ac0a/Library/Sender.ts#L102) for cached requests on disk which might cause the request to hang.

Relates to #45.
