### PR TITLE
Disable auto-collection telemetry

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -36,6 +36,12 @@ telemetry.setup = function (instrumentationKey) {
     telemetry.instrumentationKey = instrumentationKey;
 
     telemetry.appInsights.setup(instrumentationKey)
+      .setAutoCollectConsole(false)
+      .setAutoCollectDependencies(false)
+      .setAutoCollectExceptions(false)
+      .setAutoCollectPerformance(false)
+      .setAutoCollectRequests(false)
+      .setAutoDependencyCorrelation(false)
       .setUseDiskRetryCaching(false)
       .start();
 

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -50,6 +50,30 @@ describe("Telemetry", function () {
       config = {
       };
 
+      config.setAutoCollectConsole = function () {
+        return config;
+      };
+
+      config.setAutoCollectDependencies = function () {
+        return config;
+      };
+
+      config.setAutoCollectExceptions = function () {
+        return config;
+      };
+
+      config.setAutoCollectPerformance = function () {
+        return config;
+      };
+
+      config.setAutoCollectRequests = function () {
+        return config;
+      };
+
+      config.setAutoDependencyCorrelation = function () {
+        return config;
+      };
+
       config.setUseDiskRetryCaching = function () {
         return config;
       };


### PR DESCRIPTION
Disable all auto-collected ApplicationInsights telemetry to see if it resolves the AWS Lambda hangs.

Relates to #45.
