### PR TITLE
Update lambda-test-server

### DIFF
--- a/src/LondonTravel.Skill/Function.cs
+++ b/src/LondonTravel.Skill/Function.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Alexa.NET.Request;
@@ -36,12 +35,7 @@ namespace MartinCostello.LondonTravel.Skill
             var function = new AlexaFunction();
 
             using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<SkillRequest, SkillResponse>(function.HandlerAsync, serializer);
-            using var bootstrap = new LambdaBootstrap(handlerWrapper);
-
-            if (httpClient != null)
-            {
-                SetHttpClient(bootstrap, httpClient);
-            }
+            using var bootstrap = new LambdaBootstrap(httpClient ?? new HttpClient(), handlerWrapper);
 
             await bootstrap.RunAsync(cancellationToken);
         }
@@ -54,15 +48,5 @@ namespace MartinCostello.LondonTravel.Skill
         /// </returns>
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         private static async Task Main() => await RunAsync();
-
-        private static void SetHttpClient(LambdaBootstrap bootstrap, HttpClient httpClient)
-        {
-            // Replace the internal runtime API client with one using the specified HttpClient.
-            // See https://github.com/aws/aws-lambda-dotnet/blob/4f9142b95b376bd238bce6be43f4e1ec1f983592/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs#L41
-            var client = new RuntimeApiClient(httpClient);
-
-            var property = typeof(LambdaBootstrap).GetProperty("Client", BindingFlags.Instance | BindingFlags.NonPublic);
-            property.SetValue(bootstrap, client);
-        }
     }
 }

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
@@ -11,7 +11,7 @@
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="3.0.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.2.0" />
+    <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="1.1.0" />
     <PackageReference Include="JustEat.HttpClientInterception" Version="3.0.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
-    <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.1.0" />
+    <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -28,6 +28,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[Refit*]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-    <Threshold>90</Threshold>
+    <Threshold>95</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Consume changes from the latest release of `MartinCostello.Testing.AwsLambdaTestServer` and `Amazon.Lambda.RuntimeSupport`.

Will wait for v0.2.1 before merging.
