### PR TITLE
Update to prerelease version of .NET 5 RC2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,10 @@
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.3.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.15.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.1.*" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="5.0.0-rc.1.*" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="5.0.0-rc.1.*" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="5.0.0-rc.1.*" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.2.20462.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="5.0.0-rc.2.20462.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="5.0.0-rc.2.20464.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="5.0.0-rc.2.20462.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.14.5" />
@@ -24,7 +24,7 @@
     <PackageVersion Include="ReportGenerator" Version="4.6.7" />
     <PackageVersion Include="Shouldly" Version="3.0.2" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageVersion Include="System.Text.Json" Version="5.0.0-rc.1.*" />
+    <PackageVersion Include="System.Text.Json" Version="5.0.0-rc.2.20462.5" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ while :; do
     shift
 done
 
-CLI_VERSION="5.0.100-rc.1.20452.10"
+CLI_VERSION="5.0.100-rc.2.20464.14"
 
 export CLI_VERSION
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-rc.1.20452.10",
+    "version": "5.0.100-rc.2.20464.14",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }


### PR DESCRIPTION
Update to a prerelease version of .NET 5 RC2 to resolve the main branch being broken due to dotnet/runtime#42233.
