### PR TITLE
Ignore patch updates to AWSSDK.Lambda

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
   reviewers:
     - "martincostello"
   open-pull-requests-limit: 99
+  ignore:
+    - dependency-name: "AWSSDK.Lambda"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Ignore patch versions of `AWSSDK.Lambda` to stop multiple updates every week.
