### PR TITLE
Use Graviton processors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
       run: |
         aws lambda update-function-configuration \
             --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+            --architectures arm64 \
             --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
             --handler ${{ env.LAMBDA_HANDLER }} \
             --memory-size ${{ env.LAMBDA_MEMORY }} \
@@ -161,6 +162,7 @@ jobs:
       run: |
         aws lambda update-function-configuration \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
+            --architectures arm64 \
             --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
             --handler ${{ env.LAMBDA_HANDLER }} \
             --memory-size ${{ env.LAMBDA_MEMORY }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
       run: |
         aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+            --architectures arm64 \
             --publish \
             --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
             > /dev/null
@@ -119,7 +120,6 @@ jobs:
       run: |
         aws lambda update-function-configuration \
             --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-            --architectures arm64 \
             --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
             --handler ${{ env.LAMBDA_HANDLER }} \
             --memory-size ${{ env.LAMBDA_MEMORY }} \
@@ -154,6 +154,7 @@ jobs:
       run: |
         aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
+            --architectures arm64 \
             --publish \
             --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
             > /dev/null
@@ -162,7 +163,6 @@ jobs:
       run: |
         aws lambda update-function-configuration \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
-            --architectures arm64 \
             --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
             --handler ${{ env.LAMBDA_HANDLER }} \
             --memory-size ${{ env.LAMBDA_MEMORY }} \

--- a/build.ps1
+++ b/build.ps1
@@ -115,7 +115,7 @@ function DotNetPublish {
 
     if ($IsLinux) {
         $additionalArgs += "--runtime"
-        $additionalArgs += "linux-x64"
+        $additionalArgs += "linux-arm64"
         $additionalArgs += "--self-contained"
         $additionalArgs += "true"
         $additionalArgs += "/p:AssemblyName=bootstrap"


### PR DESCRIPTION
Use [Graviton processors](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/) and publish for arm64.

~Depends on the aws CLI being updated to support specifying the architecture in the `update-function-configuration` command.~ It's an argument to `update-function-code`.
