### PR TITLE
Add workaround for ICU issue

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,10 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0-rc.1.21451.13" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="6.0.0-rc.1.21452.15" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0-rc.1.21451.13" />
+    <!--
+      HACK Workaround for https://github.com/aws/aws-lambda-dotnet/issues/920
+    -->
+    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.16.1" />

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -23,6 +23,13 @@
     <PackageReference Include="Refit" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
+  <!--
+    HACK Workaround for https://github.com/aws/aws-lambda-dotnet/issues/920
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Update="Strings.Designer.cs" AutoGen="True" DependentUpon="Strings.resx" DesignTime="True" />
     <EmbeddedResource Update="Strings.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Strings.Designer.cs" />


### PR DESCRIPTION
Add workaround for Amazon Linux 2 not having a new enough ICU version pre-installed.
