### PR TITLE
Use full ICU version number

### DIFF
--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -28,7 +28,7 @@
   -->
   <ItemGroup>
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Strings.Designer.cs" AutoGen="True" DependentUpon="Strings.resx" DesignTime="True" />


### PR DESCRIPTION
Use the full version number, rather than just the major-minor pair, so the library is found correctly.
