### PR TITLE
Re-enable end-to-end tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,9 @@ jobs:
     - name: Build, Test and Package
       shell: pwsh
       run: ./build.ps1
-      #env:
-      #  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #  AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
     - uses: codecov/codecov-action@v1
       name: Upload coverage to Codecov


### PR DESCRIPTION
Re-enable the end-to-end tests.

In a future PR, will need to fix this properly as if somehow production gets broken it becomes impossible to fix it because the CI fails.
