### PR TITLE
Use arm64 processor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
       run: |
         aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+            --architectures arm64 \
             --publish \
             --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
             > /dev/null
@@ -153,6 +154,7 @@ jobs:
       run: |
         aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
+            --architectures arm64 \
             --publish \
             --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
             > /dev/null

--- a/build.ps1
+++ b/build.ps1
@@ -115,7 +115,7 @@ function DotNetPublish {
 
     if ($IsLinux) {
         $additionalArgs += "--runtime"
-        $additionalArgs += "linux-x64"
+        $additionalArgs += "linux-arm64"
         $additionalArgs += "--self-contained"
         $additionalArgs += "true"
         $additionalArgs += "/p:AssemblyName=bootstrap"


### PR DESCRIPTION
Run the lambda using arm64/Graviton processors.

Depends on the GitHub Actions' `ubuntu-latest` runner being updated to have aws cli version `2.2.43` or later.

Re-attempt of #554 that reverts #558 and #559.
