### PR TITLE
Dispose of ServiceProvider

### DIFF
--- a/src/LondonTravel.Skill/FunctionEntrypoint.cs
+++ b/src/LondonTravel.Skill/FunctionEntrypoint.cs
@@ -29,7 +29,7 @@ public static class FunctionEntrypoint
         CancellationToken cancellationToken = default)
     {
         var serializer = new JsonSerializer();
-        var function = new AlexaFunction();
+        await using var function = new AlexaFunction();
 
 #pragma warning disable CA2000
         using var handlerWrapper = HandlerWrapper.GetHandlerWrapper<SkillRequest, SkillResponse>(function.HandlerAsync, serializer);

--- a/test/LondonTravel.Skill.Tests/UnknownIntentTests.cs
+++ b/test/LondonTravel.Skill.Tests/UnknownIntentTests.cs
@@ -19,7 +19,7 @@ public class UnknownIntentTests : FunctionTests
     public async Task Can_Invoke_Function()
     {
         // Arrange
-        var function = new AlexaFunction();
+        await using var function = new AlexaFunction();
         await function.InitializeAsync();
 
         SkillRequest request = CreateIntentRequest("FooIntent");


### PR DESCRIPTION
Dispose of the `ServiceProvider` that is created by not treating it as an `IServiceProvider`.
