### PR TITLE
Use .NET 6 managed Lambda runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,10 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         cd "./artifacts/publish" || exit
-        chmod +x ./bootstrap
+        if [ -f "./bootstrap" ]
+        then
+          chmod +x ./bootstrap
+        fi
         zip -r "../${{ env.LAMBDA_FUNCTION }}.zip" . || exit 1
 
     - name: Publish deployment package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   LAMBDA_FUNCTION: 'alexa-london-travel'
-  LAMBDA_HANDLER: 'LondonTravel.Skill::MartinCostello.LondonTravel.Skill.AlexaFunction::HandlerAsync'
+  LAMBDA_HANDLER: 'LondonTravel.Skill::MartinCostello.LondonTravel.Skill.AlexaFunctionHandler::HandleAsync'
   LAMBDA_MEMORY: 256
   LAMBDA_ROLE: 'arn:aws:iam::492538393790:role/lambda_basic_execution'
-  LAMBDA_RUNTIME: 'provided.al2'
+  LAMBDA_RUNTIME: 'dotnet6'
   LAMBDA_TIMEOUT: 10
   NUGET_XMLDOC_MODE: skip
 

--- a/build.ps1
+++ b/build.ps1
@@ -113,6 +113,7 @@ function DotNetPublish {
 
     $additionalArgs = @()
 
+    <#
     if ($IsLinux) {
         $additionalArgs += "--runtime"
         $additionalArgs += "linux-arm64"
@@ -121,6 +122,7 @@ function DotNetPublish {
         $additionalArgs += "/p:AssemblyName=bootstrap"
         $additionalArgs += "/p:PublishReadyToRun=true"
     }
+    #>
 
     & $dotnet publish $Project --output $publishPath --configuration $Configuration $additionalArgs
 

--- a/src/LondonTravel.Skill/AlexaFunctionHandler.cs
+++ b/src/LondonTravel.Skill/AlexaFunctionHandler.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Alexa.NET.Request;
+using Alexa.NET.Response;
+using Amazon.Lambda.Core;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+/// <summary>
+/// A class containing the static handler function for the Lambda. This class cannot be inherited.
+/// </summary>
+public static class AlexaFunctionHandler
+{
+    private static readonly AlexaFunction _function = new();
+    private static bool _initialized;
+
+    /// <summary>
+    /// Handles a request to the skill as an asynchronous operation.
+    /// </summary>
+    /// <param name="request">The skill request.</param>
+    /// <param name="context">The current Lambda context.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the skill's response.
+    /// </returns>
+    public static async Task<SkillResponse> HandleAsync(SkillRequest request, ILambdaContext context)
+    {
+        await EnsureInitialized();
+        return await _function.HandlerAsync(request, context);
+    }
+
+    private static async Task EnsureInitialized()
+    {
+        if (!_initialized)
+        {
+            await _function.InitializeAsync();
+            _initialized = true;
+        }
+    }
+}

--- a/src/LondonTravel.Skill/aws-lambda-tools-defaults.json
+++ b/src/LondonTravel.Skill/aws-lambda-tools-defaults.json
@@ -3,8 +3,8 @@
   "region": "eu-west-1",
   "configuration": "Release",
   "framework": "net6.0",
-  "function-runtime": "provided",
+  "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 10,
-  "function-handler": "LondonTravel.Skill::MartinCostello.LondonTravel.Skill.AlexaFunction::HandlerAsync"
+  "function-handler": "LondonTravel.Skill::MartinCostello.LondonTravel.Skill.AlexaFunctionHandler::HandleAsync"
 }

--- a/test/LondonTravel.Skill.Tests/AlexaFunctionHandlerTests.cs
+++ b/test/LondonTravel.Skill.Tests/AlexaFunctionHandlerTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Alexa.NET.Request;
+using Alexa.NET.Response;
+using Amazon.Lambda.Core;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+public class AlexaFunctionHandlerTests : FunctionTests
+{
+    public AlexaFunctionHandlerTests(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task Can_Invoke_Static_Function()
+    {
+        // Arrange
+        SkillRequest request = CreateIntentRequest("AMAZON.HelpIntent");
+        ILambdaContext context = CreateContext();
+
+        // Act
+        SkillResponse actual = await AlexaFunctionHandler.HandleAsync(request, context);
+
+        // Assert
+        ResponseBody response = AssertResponse(actual, shouldEndSession: false);
+
+        response.OutputSpeech.ShouldNotBeNull();
+        response.OutputSpeech.Type.ShouldBe("SSML");
+
+        // Act
+        actual = await AlexaFunctionHandler.HandleAsync(request, context);
+
+        // Assert
+        response = AssertResponse(actual, shouldEndSession: false);
+
+        response.OutputSpeech.ShouldNotBeNull();
+        response.OutputSpeech.Type.ShouldBe("SSML");
+    }
+}


### PR DESCRIPTION
Update the Lambda function to run under the managed `dotnet6` runtime to investigate the difference.

Will roll back to managed runtime once working successfully so that .NET 7 can be used in the future.
