### PR TITLE
Remove Microsoft.ICU.ICU4C.Runtime

### DIFF
--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -26,10 +26,12 @@
   <!--
     HACK Workaround for https://github.com/aws/aws-lambda-dotnet/issues/920
   -->
+  <!--
   <ItemGroup>
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
   </ItemGroup>
+  -->
   <ItemGroup>
     <Compile Update="Strings.Designer.cs" AutoGen="True" DependentUpon="Strings.resx" DesignTime="True" />
     <EmbeddedResource Update="Strings.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Strings.Designer.cs" />


### PR DESCRIPTION
Remove Microsoft.ICU.ICU4C.Runtime to see if:

- it's not needed;
- to reduce the ZIP size to resolve [RequestEntityTooLargeException](https://github.com/martincostello/alexa-london-travel/runs/5318248047?check_suite_focus=true#step:4:27).
