### PR TITLE
Fix branding

### DIFF
--- a/src/LondonTravel.Skill/Lines.cs
+++ b/src/LondonTravel.Skill/Lines.cs
@@ -21,6 +21,18 @@ internal static class Lines
     }
 
     /// <summary>
+    /// Returns whether the specified line name refers to the Elizabeth line.
+    /// </summary>
+    /// <param name="name">The name of the line as reported from the TfL API.</param>
+    /// <returns>
+    /// A boolean indicating whether the line is the Elizabeth line.
+    /// </returns>
+    public static bool IsElizabethLine(string name)
+    {
+        return string.Equals(name, "elizabeth", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Returns whether the specified line name refers to the London Overground.
     /// </summary>
     /// <param name="name">The name of the line as reported from the TfL API.</param>
@@ -124,7 +136,10 @@ internal static class Lines
     {
         string suffix;
 
-        if (IsDlr(name) || IsOverground(name) || IsTfLRail(name))
+        if (IsDlr(name) ||
+            IsElizabethLine(name) ||
+            IsOverground(name) ||
+            IsTfLRail(name))
         {
             suffix = string.Empty;
         }

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-line-severities.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-line-severities.json
@@ -242,7 +242,7 @@
         {
           "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
           "id": "elizabeth",
-          "name": "Elizabeth Line",
+          "name": "Elizabeth line",
           "modeName": "elizabeth-line",
           "disruptions": [],
           "created": "2019-10-17T12:58:58.107Z",

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-line-statuses.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-line-statuses.json
@@ -254,7 +254,7 @@
         {
           "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
           "id": "elizabeth",
-          "name": "Elizabeth Line",
+          "name": "Elizabeth line",
           "modeName": "elizabeth-line",
           "disruptions": [],
           "created": "2019-10-17T12:58:58.107Z",
@@ -266,7 +266,7 @@
               "lineId": "elizabeth",
               "statusSeverity": 5,
               "statusSeverityDescription": "Part Closure",
-              "reason": "Elizabeth Line: Saturday 19 and Sunday 20 October, no service Canning Town to Woolwich Arsenal due to planned engineering works.",
+              "reason": "Elizabeth line: Saturday 19 and Sunday 20 October, no service Canning Town to Woolwich Arsenal due to planned engineering works.",
               "created": "0001-01-01T00:00:00",
               "validityPeriods": [
                 {
@@ -280,7 +280,7 @@
                 "$type": "Tfl.Api.Presentation.Entities.Disruption, Tfl.Api.Presentation.Entities",
                 "category": "PlannedWork",
                 "categoryDescription": "PlannedWork",
-                "description": "Elizabeth Line: Saturday 19 and Sunday 20 October, no service Canning Town to Woolwich Arsenal due to planned engineering works.",
+                "description": "Elizabeth line: Saturday 19 and Sunday 20 October, no service Canning Town to Woolwich Arsenal due to planned engineering works.",
                 "created": "2019-08-06T13:55:00Z",
                 "affectedRoutes": [],
                 "affectedStops": [],

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-multiple-disruptions.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-multiple-disruptions.json
@@ -19,6 +19,9 @@
         },
         {
           "description": "Circle Line: There are minor delays on the Circle Line."
+        },
+        {
+          "description": "Elizabeth line: There are minor delays on the Elizabeth line."
         }
       ]
     }

--- a/test/LondonTravel.Skill.Tests/DisruptionTests.cs
+++ b/test/LondonTravel.Skill.Tests/DisruptionTests.cs
@@ -71,8 +71,8 @@ public class DisruptionTests : FunctionTests
         // Assert
         AssertResponse(
             actual,
-            "<speak><p>Circle Line: There are minor delays on the Circle Line.</p><p>District Line: There are severe delays on the District Line.</p><p>Hammersmith and City Line: There are minor delays on the Hammersmith and City Line.</p><p>There is a good service on all other lines.</p></speak>",
-            "Circle Line: There are minor delays on the Circle Line.\nDistrict Line: There are severe delays on the District Line.\nHammersmith & City Line: There are minor delays on the Hammersmith & City Line.");
+            "<speak><p>Circle Line: There are minor delays on the Circle Line.</p><p>District Line: There are severe delays on the District Line.</p><p>Elizabeth line: There are minor delays on the Elizabeth line.</p><p>Hammersmith and City Line: There are minor delays on the Hammersmith and City Line.</p><p>There is a good service on all other lines.</p></speak>",
+            "Circle Line: There are minor delays on the Circle Line.\nDistrict Line: There are severe delays on the District Line.\nElizabeth line: There are minor delays on the Elizabeth line.\nHammersmith & City Line: There are minor delays on the Hammersmith & City Line.");
     }
 
     [Fact]

--- a/test/LondonTravel.Skill.Tests/StatusTests.cs
+++ b/test/LondonTravel.Skill.Tests/StatusTests.cs
@@ -31,6 +31,7 @@ public class StatusTests : FunctionTests
     [InlineData("Docklands Railway")]
     [InlineData("Elizabeth")]
     [InlineData("Elizabeth Line")]
+    [InlineData("Elizabeth line")]
     [InlineData("Hammersmith")]
     [InlineData("Hammersmith & City")]
     [InlineData("Hammersmith and City")]


### PR DESCRIPTION
- Change _"Elizabeth Line"_ to _"Elizabeth line"_.
- Fix the name being pronounced as _"Elizabeth line Line"_.

See #54.
