### PR TITLE
Fix Elizabeth line spoken name

### DIFF
--- a/src/LondonTravel.Skill/Lines.cs
+++ b/src/LondonTravel.Skill/Lines.cs
@@ -29,7 +29,7 @@ internal static class Lines
     /// </returns>
     public static bool IsElizabethLine(string name)
     {
-        return string.Equals(name, "elizabeth", StringComparison.OrdinalIgnoreCase);
+        return name.Contains("elizabeth", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/LondonTravel.Skill/Verbalizer.cs
+++ b/src/LondonTravel.Skill/Verbalizer.cs
@@ -27,6 +27,11 @@ internal static class Verbalizer
             prefix = Strings.ThePrefix;
             spokenName = Verbalize("DLR");
         }
+        else if (Lines.IsElizabethLine(name))
+        {
+            prefix = Strings.ThePrefix;
+            spokenName = name;
+        }
         else if (Lines.IsOverground(name))
         {
             spokenName = name;

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-line-statuses.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-line-statuses.json
@@ -266,7 +266,7 @@
               "lineId": "elizabeth",
               "statusSeverity": 5,
               "statusSeverityDescription": "Part Closure",
-              "reason": "Elizabeth line: Saturday 19 and Sunday 20 October, no service Canning Town to Woolwich Arsenal due to planned engineering works.",
+              "reason": "Elizabeth line: Saturday 19 and Sunday 20 October, no service Paddington to Canary Wharf due to planned engineering works.",
               "created": "0001-01-01T00:00:00",
               "validityPeriods": [
                 {
@@ -280,7 +280,7 @@
                 "$type": "Tfl.Api.Presentation.Entities.Disruption, Tfl.Api.Presentation.Entities",
                 "category": "PlannedWork",
                 "categoryDescription": "PlannedWork",
-                "description": "Elizabeth line: Saturday 19 and Sunday 20 October, no service Canning Town to Woolwich Arsenal due to planned engineering works.",
+                "description": "Elizabeth line: Saturday 19 and Sunday 20 October, no service Paddington to Canary Wharf due to planned engineering works.",
                 "created": "2019-08-06T13:55:00Z",
                 "affectedRoutes": [],
                 "affectedStops": [],

--- a/test/LondonTravel.Skill.Tests/StatusTests.cs
+++ b/test/LondonTravel.Skill.Tests/StatusTests.cs
@@ -131,6 +131,7 @@ public class StatusTests : FunctionTests
     [InlineData("Circle", "Saturday 19 and Sunday 20 October, no service between Edgware Road and Aldgate (via Victoria).")]
     [InlineData("District", "There is a good service on the District line.")]
     [InlineData("DLR", "There is a good service on the D.L.R..")]
+    [InlineData("Elizabeth line", "There is a good service on the Elizabeth line.")]
     [InlineData("Hammersmith & City", "There is a good service on the Hammersmith and City line.")]
     [InlineData("Jubilee", "There is a good service on the Jubilee line.")]
     [InlineData("London Overground", "There is a good service on London Overground.")]


### PR DESCRIPTION
Fix the name being pronounced as _"Elizabeth line Line"_.

The change in #659 only fixed the way it was written.

Relates to #54.
