### PR TITLE
Revert "Update to .NET 7"

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -3,7 +3,7 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.NetCore.Component.Runtime.7.0",
+    "Microsoft.NetCore.Component.Runtime.6.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,10 +13,10 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.6.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0-rc.1.22426.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0-rc.1.22426.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="7.0.0-rc.1.22427.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0-rc.1.22426.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="6.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <!--
       HACK Workaround for https://github.com/aws/aws-lambda-dotnet/issues/920
     -->
@@ -29,7 +29,7 @@
     <PackageVersion Include="ReportGenerator" Version="5.1.10" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.0-rc.1.22426.10" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.6" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/LondonTravel.Skill.ruleset
+++ b/LondonTravel.Skill.ruleset
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="LondonTravel.Skill Rules" Description="This rule set contains rules for the LondonTravel.Skill solution." ToolsVersion="17.0">
+<RuleSet Name="LondonTravel.Skill Rules" Description="This rule set contains rules for the LondonTravel.Skill solution." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1014" Action="None" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.1.22431.12",
+    "version": "6.0.401",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
+++ b/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
@@ -86,7 +86,7 @@ internal sealed class DisruptionIntent : IIntent
         // has a planned closure and severe delays, the message will appear twice.
         return descriptions
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Order(StringComparer.OrdinalIgnoreCase)
+            .OrderBy((p) => p, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
 }

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);CA1822</NoWarn>
     <OutputType>Exe</OutputType>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   <ItemGroup>

--- a/src/LondonTravel.Skill/aws-lambda-tools-defaults.json
+++ b/src/LondonTravel.Skill/aws-lambda-tools-defaults.json
@@ -2,8 +2,8 @@
   "profile": "alexa-london-travel",
   "region": "eu-west-1",
   "configuration": "Release",
-  "framework": "net7.0",
-  "function-runtime": "provided",
+  "framework": "net6.0",
+  "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 10,
   "function-handler": "LondonTravel.Skill::MartinCostello.LondonTravel.Skill.AlexaFunctionHandler::HandleAsync"

--- a/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
+++ b/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
@@ -3,7 +3,7 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1707;SA1600</NoWarn>
     <RootNamespace>LondonTravel.Skill.EndToEndTests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.Lambda" />

--- a/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
@@ -24,7 +24,7 @@ public class SkillTests
         {
             return Directory.GetFiles("Payloads")
                 .Select((p) => Path.GetFileNameWithoutExtension(p))
-                .Order()
+                .OrderBy((p) => p)
                 .Select((p) => new object[] { p })
                 .ToArray();
         }

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -3,7 +3,7 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LondonTravel.Skill\LondonTravel.Skill.csproj" />


### PR DESCRIPTION
Reverts martincostello/alexa-london-travel#607 due to the following issue:

```
Failed to load /var/task/libcoreclr.so, error: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /var/task/libcoreclr.so)
RequestId: {GUID} Error: Runtime exited with error: signal: segmentation fault
Runtime.ExitError
```
