### PR TITLE
Remove tflrail mode

### DIFF
--- a/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
+++ b/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
@@ -15,7 +15,7 @@ internal sealed class DisruptionIntent : IIntent
     /// <summary>
     /// The supported modes of transport. This field is read-only.
     /// </summary>
-    private static readonly string SupportedModes = string.Join(',', "dlr", "elizabeth-line", "overground", "tube", "tflrail");
+    private static readonly string SupportedModes = string.Join(',', "dlr", "elizabeth-line", "overground", "tube");
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DisruptionIntent"/> class.

--- a/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
@@ -93,6 +93,8 @@ public class SkillTests
         response.ExecutedVersion.ShouldBe("$LATEST");
 
         using var document = JsonDocument.Parse(responsePayload);
+
         document.RootElement.ValueKind.ShouldBe(JsonValueKind.Object);
+        document.RootElement.ToString().ShouldNotContain("Sorry, something went wrong.");
     }
 }

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-multiple-disruptions.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-multiple-disruptions.json
@@ -5,7 +5,7 @@
   "comment": "HTTP bundle for when there are multiple disruptions.",
   "items": [
     {
-      "uri": "https://api.tfl.gov.uk/Line/Mode/dlr%2Celizabeth-line%2Coverground%2Ctube%2Ctflrail/Disruption?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "uri": "https://api.tfl.gov.uk/Line/Mode/dlr%2Celizabeth-line%2Coverground%2Ctube/Disruption?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
       "contentFormat": "json",
       "contentJson": [
         {

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-no-disruptions.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-no-disruptions.json
@@ -5,7 +5,7 @@
   "comment": "HTTP bundle for when there is no disruption.",
   "items": [
     {
-      "uri": "https://api.tfl.gov.uk/Line/Mode/dlr%2Celizabeth-line%2Coverground%2Ctube%2Ctflrail/Disruption?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "uri": "https://api.tfl.gov.uk/Line/Mode/dlr%2Celizabeth-line%2Coverground%2Ctube/Disruption?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
       "contentFormat": "json",
       "contentJson": []
     }

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-one-disruption.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-one-disruption.json
@@ -5,7 +5,7 @@
   "comment": "HTTP bundle for when there is one disruption.",
   "items": [
     {
-      "uri": "https://api.tfl.gov.uk/Line/Mode/dlr%2Celizabeth-line%2Coverground%2Ctube%2Ctflrail/Disruption?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "uri": "https://api.tfl.gov.uk/Line/Mode/dlr%2Celizabeth-line%2Coverground%2Ctube/Disruption?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
       "contentFormat": "json",
       "contentJson": [
         {


### PR DESCRIPTION
Remove the `tflrail` mode that was replaced by the Elizabeth Line.

See https://github.com/martincostello/alexa-london-travel-site/pull/1326#issuecomment-1135515300.

Looks like this has been broken since May...
