### PR TITLE
Switch back to Graviton

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-            --architectures x86_64 \
+            --architectures arm64 \
             --publish \
             --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
             > /dev/null
@@ -187,7 +187,7 @@ jobs:
       run: |
         aws lambda update-function-code \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
-            --architectures x86_64 \
+            --architectures arm64 \
             --publish \
             --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
             > /dev/null

--- a/build.ps1
+++ b/build.ps1
@@ -97,7 +97,7 @@ function DotNetPublish {
 
     if ($IsLinux -And (-Not $UseManagedRuntime)) {
         $additionalArgs += "--runtime"
-        $additionalArgs += "linux-x64"
+        $additionalArgs += "linux-arm64"
         $additionalArgs += "--self-contained"
         $additionalArgs += "true"
         $additionalArgs += "/p:AssemblyName=bootstrap"


### PR DESCRIPTION
Switch back to using Graviton arm64 processors in AWS Lambda.

Depends on updating to .NET 7.0.4.
