### PR TITLE
.NET 8 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
       with:
         name: lambda
         path: ./artifacts/${{ env.LAMBDA_FUNCTION }}.zip
+        if-no-files-found: error
 
   deploy-dev:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.artifacts
 .DS_Store
 .dotnetcli
 .idea

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,7 @@ if ($OutputPath -eq "") {
 $installDotNetSdk = $false;
 
 if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
-    Write-Host "The .NET Core SDK is not installed."
+    Write-Host "The .NET SDK is not installed."
     $installDotNetSdk = $true
 }
 else {
@@ -32,7 +32,7 @@ else {
     }
 
     if ($installedDotNetVersion -ne $dotnetVersion) {
-        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion."
+        Write-Host "The required version of the .NET SDK is not installed. Expected $dotnetVersion."
         $installDotNetSdk = $true
     }
 }


### PR DESCRIPTION
Port changes from #732 to minimise the diff:

- Remove obsolete ".NET Core" naming.
- Ignore `.artifacts`.
- Fail build if the Lambda ZIP cannot be found.
