### PR TITLE
Update to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,12 @@ jobs:
     - name: Create Lambda ZIP file
       if: runner.os == 'Linux'
       run: |
-        cd "./artifacts/publish" || exit
+        cd "./artifacts/publish/LondonTravel.Skill/release_linux-arm64" || exit
         if [ -f "./bootstrap" ]
         then
           chmod +x ./bootstrap
         fi
-        zip -r "../${LAMBDA_FUNCTION}.zip" . || exit 1
+        zip -r "../../../${LAMBDA_FUNCTION}.zip" . || exit 1
 
     - name: Publish deployment package
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/.vsconfig
+++ b/.vsconfig
@@ -3,7 +3,7 @@
   "components": [
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Workload.CoreEditor",
-    "Microsoft.NetCore.Component.Runtime.7.0",
+    "Microsoft.NetCore.Component.Runtime.8.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>3.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -31,7 +31,7 @@
     <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
     <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
     <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
-    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(OutputPath), 'coverage'))</ReportGeneratorTargetDirectory>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
     <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
     <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,29 +13,27 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.7.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="7.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.7.23375.6" />
     <!--
       HACK Workaround for https://github.com/aws/aws-lambda-dotnet/issues/920
     -->
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.25" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.7.23375.6" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,10 +13,10 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.7.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.7.23375.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0-preview.7.23375.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.0-preview.7.23375.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.1.23419.4" />
     <!--
       HACK Workaround for https://github.com/aws/aws-lambda-dotnet/issues/920
     -->
@@ -27,7 +27,7 @@
     <PackageVersion Include="ReportGenerator" Version="5.1.25" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0-rc.1.23419.4" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.5.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23376.3",
+    "version": "8.0.100-rc.1.23455.8",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.401",
+    "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/LondonTravel.Skill/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/HttpServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ internal static class HttpServiceCollectionExtensions
         services.AddSingleton<IHttpContentSerializer>((p) =>
         {
             var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-            options.AddContext<ApplicationJsonSerializerContext>();
+            options.TypeInfoResolverChain.Add(ApplicationJsonSerializerContext.Default);
 
             return new SystemTextJsonContentSerializer(options);
         });

--- a/src/LondonTravel.Skill/Intents/CommuteIntent.cs
+++ b/src/LondonTravel.Skill/Intents/CommuteIntent.cs
@@ -15,6 +15,8 @@ namespace MartinCostello.LondonTravel.Skill.Intents;
 /// </summary>
 internal sealed class CommuteIntent : IIntent
 {
+    private static readonly CompositeFormat CommuteIntentPrefixFormat = CompositeFormat.Parse(Strings.CommuteIntentPrefixFormat);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CommuteIntent"/> class.
     /// </summary>
@@ -96,7 +98,7 @@ internal sealed class CommuteIntent : IIntent
             if (hasMultipleStatuses)
             {
                 string displayName = Verbalizer.LineName(line.Name, asTitleCase: true);
-                text = string.Format(CultureInfo.CurrentCulture, Strings.CommuteIntentPrefixFormat, displayName, text);
+                text = string.Format(CultureInfo.CurrentCulture, CommuteIntentPrefixFormat, displayName, text);
             }
 
             paragraphs.Add(text);

--- a/src/LondonTravel.Skill/Lines.cs
+++ b/src/LondonTravel.Skill/Lines.cs
@@ -8,6 +8,8 @@ namespace MartinCostello.LondonTravel.Skill;
 /// </summary>
 internal static class Lines
 {
+    private static readonly CompositeFormat StatusIntentCardTitleFormat = CompositeFormat.Parse(Strings.StatusIntentCardTitleFormat);
+
     /// <summary>
     /// Returns whether the specified line name refers to the Docklands Light Railway.
     /// </summary>
@@ -148,6 +150,6 @@ internal static class Lines
             suffix = Strings.LineSuffixUpper;
         }
 
-        return string.Format(CultureInfo.CurrentCulture, Strings.StatusIntentCardTitleFormat, name, suffix);
+        return string.Format(CultureInfo.CurrentCulture, StatusIntentCardTitleFormat, name, suffix);
     }
 }

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -5,7 +5,7 @@
     <NoWarn>$(NoWarn);CA1822</NoWarn>
     <OutputType>Exe</OutputType>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   <ItemGroup>

--- a/src/LondonTravel.Skill/Verbalizer.cs
+++ b/src/LondonTravel.Skill/Verbalizer.cs
@@ -8,6 +8,9 @@ namespace MartinCostello.LondonTravel.Skill;
 /// </summary>
 internal static class Verbalizer
 {
+    private static readonly CompositeFormat LineNameWithoutPrefixFormat = CompositeFormat.Parse(Strings.LineNameWithoutPrefixFormat);
+    private static readonly CompositeFormat LineNameWithPrefixFormat = CompositeFormat.Parse(Strings.LineNameWithPrefixFormat);
+
     /// <summary>
     /// Returns the spoken version of the specified line name.
     /// </summary>
@@ -49,8 +52,8 @@ internal static class Verbalizer
 
         return
             asTitleCase ?
-            string.Format(CultureInfo.CurrentCulture, Strings.LineNameWithoutPrefixFormat, spokenName, suffix) :
-            string.Format(CultureInfo.CurrentCulture, Strings.LineNameWithPrefixFormat, prefix, spokenName, suffix);
+            string.Format(CultureInfo.CurrentCulture, LineNameWithoutPrefixFormat, spokenName, suffix) :
+            string.Format(CultureInfo.CurrentCulture, LineNameWithPrefixFormat, prefix, spokenName, suffix);
     }
 
     /// <summary>

--- a/src/LondonTravel.Skill/aws-lambda-tools-defaults.json
+++ b/src/LondonTravel.Skill/aws-lambda-tools-defaults.json
@@ -2,7 +2,7 @@
   "profile": "alexa-london-travel",
   "region": "eu-west-1",
   "configuration": "Release",
-  "framework": "net7.0",
+  "framework": "net8.0",
   "function-runtime": "provided.al2",
   "function-memory-size": 256,
   "function-timeout": 10,

--- a/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
+++ b/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
@@ -3,7 +3,7 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1707;SA1600</NoWarn>
     <RootNamespace>LondonTravel.Skill.EndToEndTests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.Lambda" />

--- a/test/LondonTravel.Skill.Tests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.Tests/EndToEndTests.cs
@@ -46,7 +46,7 @@ public class EndToEndTests : FunctionTests
 
             if (!cancellationTokenSource.IsCancellationRequested)
             {
-                cancellationTokenSource.Cancel();
+                await cancellationTokenSource.CancelAsync();
             }
         });
 

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -3,7 +3,7 @@
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LondonTravel.Skill\LondonTravel.Skill.csproj" />
@@ -25,7 +25,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
+    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[LondonTravel.Skill.EndToEndTests]*,[Refit*]*,[xunit.*]*</Exclude>
     <Threshold>93</Threshold>


### PR DESCRIPTION
- Update to .NET 8.
- Use new artifacts output.
- Fix new code analysis warnings.
