### PR TITLE
Use OIDC for deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 env:
+  AWS_ACCOUNT_ID: '492538393790'
   AWS_REGION: eu-west-1
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
@@ -94,13 +95,19 @@ jobs:
         if-no-files-found: error
 
   deploy-dev:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: |
+      github.event.repository.fork == false &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     name: dev
     needs: build
     concurrency: development_environment
     runs-on: ubuntu-latest
+
     environment:
       name: dev
+
+    permissions:
+      id-token: write
 
     steps:
 
@@ -112,8 +119,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github-actions-deploy
+        role-session-name: github-actions-${{ github.repository }}-${{ github.run_id }}-deploy-dev
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Update function code
@@ -170,8 +177,12 @@ jobs:
     needs: tests-dev
     runs-on: ubuntu-latest
     concurrency: production_environment
+
     environment:
       name: production
+
+    permissions:
+      id-token: write
 
     steps:
 
@@ -183,8 +194,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+        role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github-actions-deploy
+        role-session-name: github-actions-${{ github.repository }}-${{ github.run_id }}-deploy-production
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Update function code


### PR DESCRIPTION
Use OIDC to authenticate with AWS for deployment instead of static access keys from secrets.

Assuming successful, will look into removing the keys used by the _tests_ in a future PR.
