### PR TITLE
Bump AWSSDK.Lambda to 3.7.200.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.8.8" />
     <PackageVersion Include="Amazon.Lambda.Serialization.Json" Version="2.1.1" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.200" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.200.1" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.2" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.0.0" />


### PR DESCRIPTION
Bumps the AWSSDK.Lambda package to 3.7.200.1.
