### PR TITLE
Update System.Globalization.AppLocalIcu

### DIFF
--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -28,7 +28,7 @@
   -->
   <ItemGroup Condition=" '$(RuntimeIdentifier)' == 'linux-arm64' ">
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
-    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2.0.9" />
+    <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Strings.Designer.cs" AutoGen="True" DependentUpon="Strings.resx" DesignTime="True" />


### PR DESCRIPTION
Update the value of `System.Globalization.AppLocalIcu` to account for the change in #828.

> Process terminated. Failed to load app-local ICU: libicudata.so.68.2.0.9
