### PR TITLE
Use actionlint docker image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,11 +30,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+    - name: Add actionlint problem matcher
+      run: echo "::add-matcher::.github/actionlint-matcher.json"
+
     - name: Lint workflows
-      shell: bash
-      env:
-        ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
-      run: |
-        echo "::add-matcher::.github/actionlint-matcher.json"
-        bash <(curl "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash")
-        ./actionlint -color
+      uses: docker://rhysd/actionlint@sha256:86ebdb1c0df5a8be92b9d53e2e0c636978a2b3c6e52c86c65a77e2c78a6bd594 # v1.6.25
+      with:
+        args: -color


### PR DESCRIPTION
Use actionlint from a Docker image to make ossf/scorecard happy.

<!-- Summarise the changes this Pull Request makes. -->

<!-- Please include a reference to a GitHub issue if appropriate. -->
