### PR TITLE
Refactor AWS Lambda deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
     - name: Wait for function code update
       run: |
-        aws lambda wait function-updated \
+        aws lambda wait function-updated-v2 \
             --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
             > /dev/null
 
@@ -217,7 +217,7 @@ jobs:
 
     - name: Wait for function code update
       run: |
-        aws lambda wait function-updated \
+        aws lambda wait function-updated-v2 \
             --function-name ${{ env.LAMBDA_FUNCTION }} \
             > /dev/null
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,10 @@ jobs:
 
     steps:
 
+    - name: Set function name
+      run: |
+        echo "FUNCTION_NAME=${{ env.LAMBDA_FUNCTION }}-dev" >> "$GITHUB_ENV"
+
     - name: Download artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
@@ -123,25 +127,10 @@ jobs:
         role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}-deploy-dev
         aws-region: ${{ env.AWS_REGION }}
 
-    - name: Update function code
-      run: |
-        aws lambda update-function-code \
-          --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-          --architectures arm64 \
-          --publish \
-          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
-          > /dev/null
-
-    - name: Wait for function code update
-      run: |
-        aws lambda wait function-updated-v2 \
-          --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-          > /dev/null
-
     - name: Update function configuration
       run: |
         aws lambda update-function-configuration \
-          --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+          --function-name "${FUNCTION_NAME}" \
           --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
           --handler ${{ env.LAMBDA_HANDLER }} \
           --memory-size ${{ env.LAMBDA_MEMORY }} \
@@ -153,7 +142,22 @@ jobs:
     - name: Wait for function configuration update
       run: |
         aws lambda wait function-updated-v2 \
-          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          --function-name "${FUNCTION_NAME}" \
+          > /dev/null
+
+    - name: Update function code
+      run: |
+        aws lambda update-function-code \
+          --function-name "${FUNCTION_NAME}" \
+          --architectures arm64 \
+          --publish \
+          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
+          > /dev/null
+
+    - name: Wait for function code update
+      run: |
+        aws lambda wait function-updated-v2 \
+          --function-name "${FUNCTION_NAME}" \
           > /dev/null
 
   tests-dev:
@@ -200,6 +204,10 @@ jobs:
 
     steps:
 
+    - name: Set function name
+      run: |
+        echo "FUNCTION_NAME=${{ env.LAMBDA_FUNCTION }}" >> "$GITHUB_ENV"
+
     - name: Download artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
@@ -212,25 +220,10 @@ jobs:
         role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}-deploy-production
         aws-region: ${{ env.AWS_REGION }}
 
-    - name: Update function code
-      run: |
-        aws lambda update-function-code \
-          --function-name ${{ env.LAMBDA_FUNCTION }} \
-          --architectures arm64 \
-          --publish \
-          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
-          > /dev/null
-
-    - name: Wait for function code update
-      run: |
-        aws lambda wait function-updated-v2 \
-          --function-name ${{ env.LAMBDA_FUNCTION }} \
-          > /dev/null
-
     - name: Update function configuration
       run: |
         aws lambda update-function-configuration \
-          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          --function-name "${FUNCTION_NAME}" \
           --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
           --handler ${{ env.LAMBDA_HANDLER }} \
           --memory-size ${{ env.LAMBDA_MEMORY }} \
@@ -242,7 +235,22 @@ jobs:
     - name: Wait for function configuration update
       run: |
         aws lambda wait function-updated-v2 \
-          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          --function-name "${FUNCTION_NAME}" \
+          > /dev/null
+
+    - name: Update function code
+      run: |
+        aws lambda update-function-code \
+          --function-name "${FUNCTION_NAME}" \
+          --architectures arm64 \
+          --publish \
+          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
+          > /dev/null
+
+    - name: Wait for function code update
+      run: |
+        aws lambda wait function-updated-v2 \
+          --function-name "${FUNCTION_NAME}" \
           > /dev/null
 
   tests-prod:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,20 @@ jobs:
         role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}-deploy-dev
         aws-region: ${{ env.AWS_REGION }}
 
+    - name: Update function code
+      run: |
+        aws lambda update-function-code \
+          --function-name "${FUNCTION_NAME}" \
+          --architectures arm64 \
+          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
+          > /dev/null
+
+    - name: Wait for function code update
+      run: |
+        aws lambda wait function-updated-v2 \
+          --function-name "${FUNCTION_NAME}" \
+          > /dev/null
+
     - name: Update function configuration
       run: |
         aws lambda update-function-configuration \
@@ -140,20 +154,6 @@ jobs:
           > /dev/null
 
     - name: Wait for function configuration update
-      run: |
-        aws lambda wait function-updated-v2 \
-          --function-name "${FUNCTION_NAME}" \
-          > /dev/null
-
-    - name: Update function code
-      run: |
-        aws lambda update-function-code \
-          --function-name "${FUNCTION_NAME}" \
-          --architectures arm64 \
-          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
-          > /dev/null
-
-    - name: Wait for function code update
       run: |
         aws lambda wait function-updated-v2 \
           --function-name "${FUNCTION_NAME}" \
@@ -219,6 +219,20 @@ jobs:
         role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}-deploy-production
         aws-region: ${{ env.AWS_REGION }}
 
+    - name: Update function code
+      run: |
+        aws lambda update-function-code \
+          --function-name "${FUNCTION_NAME}" \
+          --architectures arm64 \
+          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
+          > /dev/null
+
+    - name: Wait for function code update
+      run: |
+        aws lambda wait function-updated-v2 \
+          --function-name "${FUNCTION_NAME}" \
+          > /dev/null
+
     - name: Update function configuration
       run: |
         aws lambda update-function-configuration \
@@ -232,20 +246,6 @@ jobs:
           > /dev/null
 
     - name: Wait for function configuration update
-      run: |
-        aws lambda wait function-updated-v2 \
-          --function-name "${FUNCTION_NAME}" \
-          > /dev/null
-
-    - name: Update function code
-      run: |
-        aws lambda update-function-code \
-          --function-name "${FUNCTION_NAME}" \
-          --architectures arm64 \
-          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
-          > /dev/null
-
-    - name: Wait for function code update
       run: |
         aws lambda wait function-updated-v2 \
           --function-name "${FUNCTION_NAME}" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,6 @@ jobs:
         aws lambda update-function-code \
           --function-name "${FUNCTION_NAME}" \
           --architectures arm64 \
-          --publish \
           --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
           > /dev/null
 
@@ -158,21 +157,6 @@ jobs:
       run: |
         aws lambda wait function-updated-v2 \
           --function-name "${FUNCTION_NAME}" \
-          > /dev/null
-
-    - name: Get the latest published version
-      id: get-function-version
-      run: |
-        $functionArn = aws lambda list-versions-by-function \
-          --function-name "${FUNCTION_NAME}" \
-          --output json \
-          --query "max_by(Versions, &to_number(to_number(Version) || '0')).FunctionArn" | jq --raw-output
-        echo "function-latest-version-arn=${functionArn}" >> "$GITHUB_OUTPUT"
-
-    - name: Wait for published function version to be active
-      run: |
-        aws lambda wait published-version-active \
-          --function-name ${{ steps.get-function-version.outputs.function-latest-version-arn }} \
           > /dev/null
 
   tests-dev:
@@ -258,7 +242,6 @@ jobs:
         aws lambda update-function-code \
           --function-name "${FUNCTION_NAME}" \
           --architectures arm64 \
-          --publish \
           --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
           > /dev/null
 
@@ -266,21 +249,6 @@ jobs:
       run: |
         aws lambda wait function-updated-v2 \
           --function-name "${FUNCTION_NAME}" \
-          > /dev/null
-
-    - name: Get the latest published version
-      id: get-function-version
-      run: |
-        $functionArn = aws lambda list-versions-by-function \
-          --function-name "${FUNCTION_NAME}" \
-          --output json \
-          --query "max_by(Versions, &to_number(to_number(Version) || '0')).FunctionArn" | jq --raw-output
-        echo "function-latest-version-arn=${functionArn}" >> "$GITHUB_OUTPUT"
-
-    - name: Wait for published function version to be active
-      run: |
-        aws lambda wait published-version-active \
-          --function-name ${{ steps.get-function-version.outputs.function-latest-version-arn }} \
           > /dev/null
 
   tests-prod:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,12 @@ jobs:
             --timeout ${{ env.LAMBDA_TIMEOUT }} \
             > /dev/null
 
+    - name: Wait for function configuration update
+      run: |
+        aws lambda wait function-updated-v2 \
+            --function-name ${{ env.LAMBDA_FUNCTION }} \
+            > /dev/null
+
   tests-dev:
     name: tests-dev
     needs: deploy-dev
@@ -231,6 +237,12 @@ jobs:
             --role ${{ env.LAMBDA_ROLE }} \
             --runtime ${{ env.LAMBDA_RUNTIME }} \
             --timeout ${{ env.LAMBDA_TIMEOUT }} \
+            > /dev/null
+
+    - name: Wait for function configuration update
+      run: |
+        aws lambda wait function-updated-v2 \
+            --function-name ${{ env.LAMBDA_FUNCTION }} \
             > /dev/null
 
   tests-prod:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,35 +126,35 @@ jobs:
     - name: Update function code
       run: |
         aws lambda update-function-code \
-            --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-            --architectures arm64 \
-            --publish \
-            --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+          --architectures arm64 \
+          --publish \
+          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
+          > /dev/null
 
     - name: Wait for function code update
       run: |
         aws lambda wait function-updated-v2 \
-            --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+          > /dev/null
 
     - name: Update function configuration
       run: |
         aws lambda update-function-configuration \
-            --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
-            --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
-            --handler ${{ env.LAMBDA_HANDLER }} \
-            --memory-size ${{ env.LAMBDA_MEMORY }} \
-            --role ${{ env.LAMBDA_ROLE }} \
-            --runtime ${{ env.LAMBDA_RUNTIME }} \
-            --timeout ${{ env.LAMBDA_TIMEOUT }} \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }}-dev \
+          --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
+          --handler ${{ env.LAMBDA_HANDLER }} \
+          --memory-size ${{ env.LAMBDA_MEMORY }} \
+          --role ${{ env.LAMBDA_ROLE }} \
+          --runtime ${{ env.LAMBDA_RUNTIME }} \
+          --timeout ${{ env.LAMBDA_TIMEOUT }} \
+          > /dev/null
 
     - name: Wait for function configuration update
       run: |
         aws lambda wait function-updated-v2 \
-            --function-name ${{ env.LAMBDA_FUNCTION }} \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          > /dev/null
 
   tests-dev:
     name: tests-dev
@@ -215,35 +215,35 @@ jobs:
     - name: Update function code
       run: |
         aws lambda update-function-code \
-            --function-name ${{ env.LAMBDA_FUNCTION }} \
-            --architectures arm64 \
-            --publish \
-            --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          --architectures arm64 \
+          --publish \
+          --zip-file fileb://./${{ env.LAMBDA_FUNCTION }}.zip \
+          > /dev/null
 
     - name: Wait for function code update
       run: |
         aws lambda wait function-updated-v2 \
-            --function-name ${{ env.LAMBDA_FUNCTION }} \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          > /dev/null
 
     - name: Update function configuration
       run: |
         aws lambda update-function-configuration \
-            --function-name ${{ env.LAMBDA_FUNCTION }} \
-            --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
-            --handler ${{ env.LAMBDA_HANDLER }} \
-            --memory-size ${{ env.LAMBDA_MEMORY }} \
-            --role ${{ env.LAMBDA_ROLE }} \
-            --runtime ${{ env.LAMBDA_RUNTIME }} \
-            --timeout ${{ env.LAMBDA_TIMEOUT }} \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          --description "Deploy build ${{ github.run_number }} to AWS Lambda via GitHub Actions" \
+          --handler ${{ env.LAMBDA_HANDLER }} \
+          --memory-size ${{ env.LAMBDA_MEMORY }} \
+          --role ${{ env.LAMBDA_ROLE }} \
+          --runtime ${{ env.LAMBDA_RUNTIME }} \
+          --timeout ${{ env.LAMBDA_TIMEOUT }} \
+          > /dev/null
 
     - name: Wait for function configuration update
       run: |
         aws lambda wait function-updated-v2 \
-            --function-name ${{ env.LAMBDA_FUNCTION }} \
-            > /dev/null
+          --function-name ${{ env.LAMBDA_FUNCTION }} \
+          > /dev/null
 
   tests-prod:
     name: tests-prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,21 @@ jobs:
           --function-name "${FUNCTION_NAME}" \
           > /dev/null
 
+    - name: Get the latest published version
+      id: get-function-version
+      run: |
+        $functionArn = aws lambda list-versions-by-function \
+          --function-name "${FUNCTION_NAME}" \
+          --output json \
+          --query "max_by(Versions, &to_number(to_number(Version) || '0')).FunctionArn" | jq --raw-output
+        echo "function-latest-version-arn=${functionArn}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for published function version to be active
+      run: |
+        aws lambda wait published-version-active \
+          --function-name ${{ steps.get-function-version.outputs.function-latest-version-arn }} \
+          > /dev/null
+
   tests-dev:
     name: tests-dev
     needs: deploy-dev
@@ -251,6 +266,21 @@ jobs:
       run: |
         aws lambda wait function-updated-v2 \
           --function-name "${FUNCTION_NAME}" \
+          > /dev/null
+
+    - name: Get the latest published version
+      id: get-function-version
+      run: |
+        $functionArn = aws lambda list-versions-by-function \
+          --function-name "${FUNCTION_NAME}" \
+          --output json \
+          --query "max_by(Versions, &to_number(to_number(Version) || '0')).FunctionArn" | jq --raw-output
+        echo "function-latest-version-arn=${functionArn}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for published function version to be active
+      run: |
+        aws lambda wait published-version-active \
+          --function-name ${{ steps.get-function-version.outputs.function-latest-version-arn }} \
           > /dev/null
 
   tests-prod:


### PR DESCRIPTION
- Stop publishing versions of the functions.
- Use environment variables to pass through the function name.
- Use `function-updated-v2` to wait for changes.
- Wait for the configuration up to complete before completing the deployment job.
