### PR TITLE
Make AoT friendlier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   groups:
+    polly:
+      patterns:
+        - Polly*
     xunit:
       patterns:
         - xunit*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.8.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
@@ -25,7 +26,6 @@
     <PackageVersion Include="Polly.Core" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.Extensions" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.RateLimiting" Version="$(PollyVersion)" />
-    <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.2.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Polly.Core" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.Extensions" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.RateLimiting" Version="$(PollyVersion)" />

--- a/src/LondonTravel.Skill/AppJsonSerializerContext.cs
+++ b/src/LondonTravel.Skill/AppJsonSerializerContext.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+using MartinCostello.LondonTravel.Skill.Clients;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+/// <summary>
+/// A class representing the <see cref="JsonSerializerContext"/> to use for the application.
+/// </summary>
+[JsonSerializable(typeof(IList<Line>))]
+[JsonSerializable(typeof(IList<ServiceDisruption>))]
+[JsonSerializable(typeof(SkillUserPreferences))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class AppJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/LondonTravel.Skill/Clients/SkillClient.cs
+++ b/src/LondonTravel.Skill/Clients/SkillClient.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using Refit;
+using System.Net.Http.Json;
 
 namespace MartinCostello.LondonTravel.Skill.Clients;
 
 /// <summary>
 /// Defines the client for the skill's API.
 /// </summary>
-internal interface ISkillClient
+internal sealed class SkillClient(HttpClient httpClient)
 {
     /// <summary>
     /// Get the current user's preferences from the skill's API as an asynchronous operation.
@@ -18,8 +18,11 @@ internal interface ISkillClient
     /// <returns>
     /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the current user's preferences from the skill API.
     /// </returns>
-    [Get("/api/preferences")]
-    Task<SkillUserPreferences> GetPreferencesAsync(
-        [Header("Authorization")] string authorization,
-        CancellationToken cancellationToken = default);
+    public async Task<SkillUserPreferences> GetPreferencesAsync(
+        string authorization,
+        CancellationToken cancellationToken = default)
+    {
+        httpClient.DefaultRequestHeaders.Authorization = new("Bearer", authorization);
+        return await httpClient.GetFromJsonAsync("/api/preferences", AppJsonSerializerContext.Default.SkillUserPreferences, cancellationToken);
+    }
 }

--- a/src/LondonTravel.Skill/Clients/TflClient.cs
+++ b/src/LondonTravel.Skill/Clients/TflClient.cs
@@ -1,14 +1,15 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using Refit;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace MartinCostello.LondonTravel.Skill.Clients;
 
 /// <summary>
 /// Defines an HTTP client for the TfL API.
 /// </summary>
-internal interface ITflClient
+internal sealed class TflClient(HttpClient httpClient)
 {
     /// <summary>
     /// Gets the disruption for the specified modes of travel as an asynchronous operation.
@@ -21,12 +22,15 @@ internal interface ITflClient
     /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the
     /// disruption for the modes specified by <paramref name="modes"/>.
     /// </returns>
-    [Get("/Line/Mode/{modes}/Disruption")]
-    Task<IList<ServiceDisruption>> GetDisruptionAsync(
+    public async Task<IList<ServiceDisruption>> GetDisruptionAsync(
         string modes,
-        [AliasAs("app_id")] string applicationId,
-        [AliasAs("app_key")] string applicationKey,
-        CancellationToken cancellationToken = default);
+        string applicationId,
+        string applicationKey,
+        CancellationToken cancellationToken = default)
+    {
+        string requestUrl = GetRequestUrl($"/Line/Mode/{Uri.EscapeDataString(modes)}/Disruption", applicationId, applicationKey);
+        return await httpClient.GetFromJsonAsync(requestUrl, AppJsonSerializerContext.Default.IListServiceDisruption, cancellationToken);
+    }
 
     /// <summary>
     /// Gets the statuses for the specified line Ids as an asynchronous operation.
@@ -39,10 +43,27 @@ internal interface ITflClient
     /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the
     /// statuses of for the line Ids specified by <paramref name="ids"/>.
     /// </returns>
-    [Get("/Line/{ids}/Status")]
-    Task<IList<Line>> GetLineStatusAsync(
+    public async Task<IList<Line>> GetLineStatusAsync(
         string ids,
-        [AliasAs("app_id")] string applicationId,
-        [AliasAs("app_key")] string applicationKey,
-        CancellationToken cancellationToken = default);
+        string applicationId,
+        string applicationKey,
+        CancellationToken cancellationToken = default)
+    {
+        string requestUrl = GetRequestUrl($"/Line/{Uri.EscapeDataString(ids)}/Status", applicationId, applicationKey);
+        return await httpClient.GetFromJsonAsync(requestUrl, AppJsonSerializerContext.Default.IListLine, cancellationToken);
+    }
+
+    private static string GetRequestUrl(
+        string uri,
+        string applicationId,
+        string applicationKey)
+    {
+        KeyValuePair<string, string>[] parameters =
+        [
+            KeyValuePair.Create("app_id", applicationId),
+            KeyValuePair.Create("app_key", applicationKey),
+        ];
+
+        return QueryHelpers.AddQueryString(uri, parameters);
+    }
 }

--- a/src/LondonTravel.Skill/Intents/CommuteIntent.cs
+++ b/src/LondonTravel.Skill/Intents/CommuteIntent.cs
@@ -6,7 +6,6 @@ using Alexa.NET.Request;
 using Alexa.NET.Response;
 using MartinCostello.LondonTravel.Skill.Clients;
 using Microsoft.Extensions.Logging;
-using Refit;
 
 namespace MartinCostello.LondonTravel.Skill.Intents;
 
@@ -22,8 +21,8 @@ namespace MartinCostello.LondonTravel.Skill.Intents;
 /// <param name="config">The skill configuration to use.</param>
 /// <param name="logger">The logger to use.</param>
 internal sealed class CommuteIntent(
-    ISkillClient skillClient,
-    ITflClient tflClient,
+    SkillClient skillClient,
+    TflClient tflClient,
     SkillConfiguration config,
     ILogger<CommuteIntent> logger) : IIntent
 {
@@ -86,10 +85,10 @@ internal sealed class CommuteIntent(
     {
         try
         {
-            SkillUserPreferences preferences = await skillClient.GetPreferencesAsync($"Bearer {accessToken}");
+            SkillUserPreferences preferences = await skillClient.GetPreferencesAsync(accessToken);
             return preferences.FavoriteLines ?? Array.Empty<string>();
         }
-        catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
         {
             return null;
         }

--- a/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
+++ b/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
@@ -15,7 +15,7 @@ namespace MartinCostello.LondonTravel.Skill.Intents;
 /// </remarks>
 /// <param name="tflClient">The TfL API client to use.</param>
 /// <param name="config">The skill configuration to use.</param>
-internal sealed class DisruptionIntent(ITflClient tflClient, SkillConfiguration config) : IIntent
+internal sealed class DisruptionIntent(TflClient tflClient, SkillConfiguration config) : IIntent
 {
     /// <summary>
     /// The supported modes of transport. This field is read-only.

--- a/src/LondonTravel.Skill/Intents/StatusIntent.cs
+++ b/src/LondonTravel.Skill/Intents/StatusIntent.cs
@@ -16,7 +16,7 @@ namespace MartinCostello.LondonTravel.Skill.Intents;
 /// </remarks>
 /// <param name="tflClient">The TfL API client to use.</param>
 /// <param name="config">The skill configuration to use.</param>
-internal sealed class StatusIntent(ITflClient tflClient, SkillConfiguration config) : IIntent
+internal sealed class StatusIntent(TflClient tflClient, SkillConfiguration config) : IIntent
 {
     /// <inheritdoc />
     public async Task<SkillResponse> RespondAsync(Intent intent, Session session)

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AWSProjectType>Lambda</AWSProjectType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -15,6 +15,7 @@
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="Amazon.Lambda.Serialization.Json" />
     <PackageReference Include="Microsoft.ApplicationInsights" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
@@ -22,7 +23,6 @@
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />
-    <PackageReference Include="Refit" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -28,6 +28,7 @@
     <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[LondonTravel.Skill.EndToEndTests]*,[Refit*]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
     <Threshold>93</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Remove use of Refit to be AoT-friendlier. AoT is not supported though due to trimmer warnings from Newtonsoft.Json (via Alexa.NET) (see https://github.com/timheuer/alexa-skills-dotnet/issues/262) and Microsoft.ApplicationInsights.
- Bump Newtonsoft.Json to 13.0.3.
- Group dependabot NuGet package updates for Polly.
