### PR TITLE
Optimise for speed

### DIFF
--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -3,8 +3,10 @@
     <AWSProjectType>Lambda</AWSProjectType>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <IlcInstructionSet>armv8.2-a</IlcInstructionSet>
     <InvariantGlobalization>true</InvariantGlobalization>
     <NoWarn>$(NoWarn);CA1822</NoWarn>
+    <OptimizationPreference>Speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <PublishAot>true</PublishAot>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>


### PR DESCRIPTION
Optimise AoT for speed and target Amazon Graviton processors.

Requested via [Twitter](https://x.com/socketnorm/status/1730320725448569263).
