### PR TITLE
Output CloudWatch logs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,7 @@ updates:
     - "martincostello"
   open-pull-requests-limit: 99
   ignore:
+    - dependency-name: "AWSSDK.CloudWatchLogs"
+      update-types: ["version-update:semver-patch"]
     - dependency-name: "AWSSDK.Lambda"
       update-types: ["version-update:semver-patch"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -385,7 +385,9 @@ jobs:
       shell: pwsh
       run: dotnet test ./test/LondonTravel.Skill.EndToEndTests --configuration Release --logger "GitHubActions;report-warnings=false"
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         LAMBDA_FUNCTION_NAME: ${{ needs.setup.outputs.function-name }}
+        PULL_NUMBER: ${{ github.event.issue.number }}
 
     - name: Post comment
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="3.7.301.4" />
     <PackageVersion Include="AWSSDK.Lambda" Version="3.7.303.8" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.300.1" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.303.8" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.0.0" />

--- a/LondonTravel.Skill.sln
+++ b/LondonTravel.Skill.sln
@@ -66,8 +66,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
-		.github\workflows\linter.yml = .github\workflows\linter.yml
-		.github\workflows\update-dotnet-sdk.yml = .github\workflows\update-dotnet-sdk.yml
+		.github\workflows\dependency-review.yml = .github\workflows\dependency-review.yml
+		.github\workflows\deploy.yml = .github\workflows\deploy.yml
+		.github\workflows\lint.yml = .github\workflows\lint.yml
+		.github\workflows\ossf-scorecard.yml = .github\workflows\ossf-scorecard.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LondonTravel.Skill.EndToEndTests", "test\LondonTravel.Skill.EndToEndTests\LondonTravel.Skill.EndToEndTests.csproj", "{385B221D-16BF-4703-8105-C8622C188B1A}"

--- a/LondonTravel.Skill.sln
+++ b/LondonTravel.Skill.sln
@@ -27,7 +27,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{791C7C14-F862-41ED-9D92-12F844223C1B}"
 	ProjectSection(SolutionItems) = preProject
+		.github\actionlint-matcher.json = .github\actionlint-matcher.json
+		.github\CODEOWNERS = .github\CODEOWNERS
 		.github\CONTRIBUTING.md = .github\CONTRIBUTING.md
+		.github\dependabot.yml = .github\dependabot.yml
+		.github\FUNDING.yml = .github\FUNDING.yml
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 	EndProjectSection

--- a/test/LondonTravel.Skill.EndToEndTests/AwsConfiguration.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/AwsConfiguration.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Amazon.Runtime;
+
+namespace LondonTravel.Skill.EndToEndTests;
+
+internal static class AwsConfiguration
+{
+    public static string FunctionName => Environment.GetEnvironmentVariable("LAMBDA_FUNCTION_NAME");
+
+    public static string RegionName => Environment.GetEnvironmentVariable("AWS_REGION");
+
+    public static AWSCredentials GetCredentials()
+    {
+        try
+        {
+            return new EnvironmentVariablesAWSCredentials();
+        }
+        catch (InvalidOperationException)
+        {
+            // Not configured
+        }
+
+        try
+        {
+            return AssumeRoleWithWebIdentityCredentials.FromEnvironmentVariables();
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+}

--- a/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
@@ -15,6 +15,11 @@ public class CloudWatchLogsFixture(IMessageSink diagnosticMessageSink) : IAsyncL
 
     public async Task DisposeAsync()
     {
+        if (RequestIds.Count < 1)
+        {
+            return;
+        }
+
         var credentials = AwsConfiguration.GetCredentials();
         string functionName = AwsConfiguration.FunctionName;
         string regionName = AwsConfiguration.RegionName;

--- a/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Amazon;
+using Amazon.CloudWatchLogs;
+using Xunit.Sdk;
+
+namespace LondonTravel.Skill.EndToEndTests;
+
+public class CloudWatchLogsFixture(IMessageSink diagnosticMessageSink) : IAsyncLifetime
+{
+    private readonly DateTime _started = TimeProvider.System.GetUtcNow().UtcDateTime;
+
+    public IList<string> RequestIds { get; } = new List<string>();
+
+    public async Task DisposeAsync()
+    {
+        var credentials = AwsConfiguration.GetCredentials();
+        string functionName = AwsConfiguration.FunctionName;
+        string regionName = AwsConfiguration.RegionName;
+
+        if (functionName is not null &&
+            regionName is not null &&
+            credentials is not null)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            string logGroupName = $"/aws/lambda/{functionName}";
+            var region = RegionEndpoint.GetBySystemName(regionName);
+
+            using var logsClient = new AmazonCloudWatchLogsClient(credentials, region);
+
+            var groups = await logsClient.DescribeLogStreamsAsync(new()
+            {
+                Descending = true,
+                Limit = Math.Max(5, RequestIds.Count),
+                LogGroupName = logGroupName,
+                OrderBy = OrderBy.LastEventTime,
+            });
+
+            var logs = new List<(DateTime Timestamp, string RequestId, string Message)>();
+
+            foreach (var stream in groups.LogStreams)
+            {
+                var logEvents = await logsClient.GetLogEventsAsync(new()
+                {
+                    LogGroupName = logGroupName,
+                    LogStreamName = stream.LogStreamName,
+                });
+
+                const string ReportPrefix = "REPORT ";
+
+                var reports = logEvents.Events
+                    .Where((p) => p.Timestamp >= _started)
+                    .Where((p) => p.Message.StartsWith(ReportPrefix, StringComparison.Ordinal))
+                    .ToList();
+
+                foreach (var @event in reports)
+                {
+                    string[] split = @event.Message.Split('\t', StringSplitOptions.RemoveEmptyEntries);
+                    string requestId = split[0][ReportPrefix.Length..];
+
+                    var builder = new StringBuilder()
+                        .AppendLine()
+                        .AppendLine()
+                        .AppendFormat(CultureInfo.InvariantCulture, $"Timestamp: {@event.Timestamp:u}")
+                        .AppendLine()
+                        .AppendLine(requestId);
+
+                    foreach (string value in split.Skip(1))
+                    {
+                        if (value.Trim() is { Length: > 0 } trimmed)
+                        {
+                            builder.AppendLine(trimmed);
+                        }
+                    }
+
+                    logs.Add(new(@event.Timestamp, requestId, builder.ToString()));
+                }
+            }
+
+            var events = logs
+                .Where((p) => RequestIds.Contains(p.RequestId))
+                .OrderBy((p) => p.Timestamp)
+                .ToList();
+
+            foreach (var (_, _, message) in events)
+            {
+                diagnosticMessageSink.OnMessage(new DiagnosticMessage(message));
+            }
+        }
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixtureCollection.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixtureCollection.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace LondonTravel.Skill.EndToEndTests;
+
+[CollectionDefinition(Name)]
+public class CloudWatchLogsFixtureCollection : ICollectionFixture<CloudWatchLogsFixture>
+{
+    public const string Name = "CloudWatch Logs";
+}

--- a/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
+++ b/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1707;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1707;CA1711;SA1600</NoWarn>
     <RootNamespace>LondonTravel.Skill.EndToEndTests</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AWSSDK.CloudWatchLogs" />
     <PackageReference Include="AWSSDK.Lambda" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
@@ -64,7 +64,7 @@ public class SkillTests(CloudWatchLogsFixture fixture, ITestOutputHelper outputH
         invocation.ShouldNotBeNull();
         invocation.ResponseMetadata.ShouldNotBeNull();
 
-        fixture.RequestIds.Add(invocation.ResponseMetadata.RequestId);
+        fixture.Requests[invocation.ResponseMetadata.RequestId] = payloadName;
 
         using var reader = new StreamReader(invocation.Payload);
         string responsePayload = await reader.ReadToEndAsync();

--- a/test/LondonTravel.Skill.EndToEndTests/xunit.runner.json
+++ b/test/LondonTravel.Skill.EndToEndTests/xunit.runner.json
@@ -1,3 +1,4 @@
 {
+  "diagnosticMessages": true,
   "methodDisplay": "method"
 }

--- a/test/LondonTravel.Skill.EndToEndTests/xunit.runner.json
+++ b/test/LondonTravel.Skill.EndToEndTests/xunit.runner.json
@@ -1,4 +1,4 @@
 {
-  "methodDisplay": "method",
-  "methodDisplayOptions": "replaceUnderscoreWithSpace"
+  "diagnosticMessages": true,
+  "methodDisplay": "method"
 }

--- a/test/LondonTravel.Skill.EndToEndTests/xunit.runner.json
+++ b/test/LondonTravel.Skill.EndToEndTests/xunit.runner.json
@@ -1,4 +1,3 @@
 {
-  "diagnosticMessages": true,
   "methodDisplay": "method"
 }


### PR DESCRIPTION
- Log the `REPORT` metrics for Lambda invocations when running end-to-end tests and into a comment in a pull request.
- Improve the assertions for the lambda invocations.
- Update AWSSDK.Lambda.
