### PR TITLE
Specify github-token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,6 +122,7 @@ jobs:
     - name: 'Download artifact from #${{ github.event.issue.number }}'
       uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
       with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         name: ${{ env.ARTIFACT_NAME }}
         run-id: ${{ steps.get-run.outputs.run-id }}
 


### PR DESCRIPTION
Specify `github-token` so downloading from another workflow run works correctly.
