### PR TITLE
Increase value range

### DIFF
--- a/test/LondonTravel.Skill.Tests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.Tests/EndToEndTests.cs
@@ -155,7 +155,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
 
         result.ShouldNotBeNull();
         result.IsSuccessful.ShouldBeTrue();
-        result.Duration.ShouldBeInRange(TimeSpan.FromTicks(1), TimeSpan.FromSeconds(1));
+        result.Duration.ShouldBeInRange(TimeSpan.FromTicks(1), TimeSpan.FromSeconds(2));
         result.Content.ShouldNotBeEmpty();
 
         json = await result.ReadAsStringAsync();


### PR DESCRIPTION
Increase upper limit in execution time assertion to 2 seconds as sometimes in CI it just goes above 1 second and fails.
