### PR TITLE
Fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   groups:
+    awssdk:
+      patterns:
+        - AWSSDK*
     opentelemetry:
       patterns:
         - OpenTelemetry*
@@ -29,18 +32,4 @@ updates:
   open-pull-requests-limit: 99
   ignore:
     - dependency-name: "AWSSDK*"
-- package-ecosystem: nuget
-  directory: "/"
-  groups:
-    awssdk:
-      patterns:
-        - AWSSDK*
-  schedule:
-    interval: monthly
-    time: "05:30"
-    timezone: Europe/London
-  reviewers:
-    - "martincostello"
-  open-pull-requests-limit: 99
-  allow:
-    - dependency-name: "AWSSDK*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Turns out you can't have multiple schedules for the same package ecosystem.
