### PR TITLE
Enrich HTTP traces

### DIFF
--- a/src/LondonTravel.Skill/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/HttpServiceCollectionExtensions.cs
@@ -29,7 +29,11 @@ internal static class HttpServiceCollectionExtensions
             client.BaseAddress = config.SkillApiUrl;
         });
 
-        services.AddHttpClient<TflClient>((p) => p.BaseAddress = new Uri("https://api.tfl.gov.uk/", UriKind.Absolute));
+        services.AddHttpClient<TflClient>((provider, client) =>
+        {
+            var config = provider.GetRequiredService<SkillConfiguration>();
+            client.BaseAddress = config.TflApiUrl;
+        });
 
         return services;
     }

--- a/src/LondonTravel.Skill/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/HttpServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ internal static class HttpServiceCollectionExtensions
         services.AddHttpClient<SkillClient>((provider, client) =>
         {
             var config = provider.GetRequiredService<SkillConfiguration>();
-            client.BaseAddress = new Uri(config.SkillApiUrl, UriKind.Absolute);
+            client.BaseAddress = config.SkillApiUrl;
         });
 
         services.AddHttpClient<TflClient>((p) => p.BaseAddress = new Uri("https://api.tfl.gov.uk/", UriKind.Absolute));

--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -79,7 +79,7 @@ internal static class TelemetryExtensions
         mappings[options.TflApiUrl.Host] = "TfL API";
 
         if (configuration["AWS_LAMBDA_RUNTIME_API"] is { Length: > 0 } url &&
-            Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            Uri.TryCreate($"http://{url}", UriKind.Absolute, out var uri))
         {
             mappings[uri.Host] = "AWS Lambda Runtime API";
         }

--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -10,6 +14,8 @@ namespace MartinCostello.LondonTravel.Skill.Extensions;
 
 internal static class TelemetryExtensions
 {
+    private static readonly Dictionary<string, string> ServiceMap = new(StringComparer.OrdinalIgnoreCase);
+
     public static IServiceCollection AddTelemetry(this IServiceCollection services)
     {
         services.AddSingleton((_) => SkillTelemetry.ActivitySource);
@@ -17,7 +23,7 @@ internal static class TelemetryExtensions
                 .ConfigureResource((builder) => builder.AddService(SkillTelemetry.ServiceName, serviceVersion: SkillTelemetry.ServiceVersion))
                 .WithTracing((builder) =>
                 {
-                    builder.AddHttpClientInstrumentation((p) => p.RecordException = true)
+                    builder.AddHttpClientInstrumentation()
                            .AddSource(SkillTelemetry.ServiceName);
 
                     if (IsRunningInAwsLambda())
@@ -27,10 +33,55 @@ internal static class TelemetryExtensions
                     }
                 });
 
+        services.AddOptions<HttpClientTraceInstrumentationOptions>()
+                .Configure<IServiceProvider>((options, provider) =>
+                {
+                    AddServiceMappings(ServiceMap, provider);
+
+                    options.EnrichWithHttpRequestMessage = EnrichHttpActivity;
+                    options.RecordException = true;
+                });
+
         return services;
     }
 
     private static bool IsRunningInAwsLambda()
         => Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME") is { Length: > 0 } &&
            Environment.GetEnvironmentVariable("AWS_REGION") is { Length: > 0 };
+
+    private static void EnrichHttpActivity(Activity activity, HttpRequestMessage request)
+    {
+        TryEnrichWithPeerService(activity);
+
+        static void TryEnrichWithPeerService(Activity activity)
+        {
+            if (GetTag("server.address", activity.Tags) is { Length: > 0 } hostName)
+            {
+                if (!ServiceMap.TryGetValue(hostName, out string? service))
+                {
+                    service = hostName;
+                }
+
+                activity.AddTag("peer.service", service);
+            }
+        }
+
+        static string? GetTag(string name, IEnumerable<KeyValuePair<string, string?>> tags)
+            => tags.FirstOrDefault((p) => p.Key == name).Value;
+    }
+
+    private static void AddServiceMappings(Dictionary<string, string> mappings, IServiceProvider serviceProvider)
+    {
+        var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+        var options = serviceProvider.GetRequiredService<IOptions<SkillConfiguration>>().Value;
+
+        mappings[options.SkillApiUrl.Host] = "Skill API";
+        mappings[options.TflApiUrl.Host] = "TfL API";
+
+        if (configuration["AWS_LAMBDA_RUNTIME_API"] is { Length: > 0 } url &&
+            Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            mappings[uri.Host] = "AWS Lambda Runtime API";
+        }
+    }
 }

--- a/src/LondonTravel.Skill/SkillConfiguration.cs
+++ b/src/LondonTravel.Skill/SkillConfiguration.cs
@@ -14,7 +14,7 @@ public sealed class SkillConfiguration
     /// Gets or sets the URL for the skill API.
     /// </summary>
     [Required]
-    public string SkillApiUrl { get; set; } = string.Empty;
+    public Uri SkillApiUrl { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the skill's ID.

--- a/src/LondonTravel.Skill/SkillConfiguration.cs
+++ b/src/LondonTravel.Skill/SkillConfiguration.cs
@@ -22,6 +22,12 @@ public sealed class SkillConfiguration
     public string SkillId { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the URL for the TfL API.
+    /// </summary>
+    [Required]
+    public Uri TflApiUrl { get; set; } = default!;
+
+    /// <summary>
     /// Gets or sets the TfL API application Id.
     /// </summary>
     [Required]

--- a/src/LondonTravel.Skill/appsettings.json
+++ b/src/LondonTravel.Skill/appsettings.json
@@ -10,6 +10,7 @@
   "Skill": {
     "SkillApiUrl": "",
     "SkillId": "",
+    "TflApiUrl": "https://api.tfl.gov.uk/",
     "TflApplicationId": "",
     "TflApplicationKey": "",
     "VerifySkillId": false

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -29,6 +29,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[LondonTravel.Skill.EndToEndTests]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
-    <Threshold>88</Threshold>
+    <Threshold>87</Threshold>
   </PropertyGroup>
 </Project>

--- a/test/LondonTravel.Skill.Tests/testsettings.json
+++ b/test/LondonTravel.Skill.Tests/testsettings.json
@@ -10,6 +10,7 @@
   "Skill": {
     "SkillApiUrl": "https://londontravel.martincostello.local/",
     "SkillId": "my-skill-id",
+    "TflApiUrl": "https://api.tfl.gov.uk/",
     "TflApplicationId": "my-tfl-app-id",
     "TflApplicationKey": "my-tfl-app-key",
     "VerifySkillId": true


### PR DESCRIPTION
- Enrich HTTP request traces with the `peer.service` tag.
- Refactor the Skill API base address to be a `Uri` instead of a `string`.
- Move the base address for the TfL API to configuration, rather than being hard-coded.
