### PR TITLE
Remove PollyVersion property

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <PollyVersion>8.3.1</PollyVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
@@ -32,9 +29,9 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.3.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
-    <PackageVersion Include="Polly.Core" Version="$(PollyVersion)" />
-    <PackageVersion Include="Polly.Extensions" Version="$(PollyVersion)" />
-    <PackageVersion Include="Polly.RateLimiting" Version="$(PollyVersion)" />
+    <PackageVersion Include="Polly.Core" Version="8.3.0" />
+    <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.3.0" />
     <PackageVersion Include="ReportGenerator" Version="5.2.2" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
Remove the `PollyVersion` MSBuild property and downgrade to 8.3.0 to test dependabot/dependabot-core#8576.
