### PR TITLE
Solution improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,16 @@ indent_size = 2
 end_of_line = lf
 
 [*.cs]
+
+dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+dotnet_diagnostic.IDE0005.severity = silent
+dotnet_diagnostic.IDE0045.severity = silent
+dotnet_diagnostic.IDE0046.severity = silent
+dotnet_diagnostic.IDE0058.severity = silent
+dotnet_diagnostic.IDE0072.severity = silent
+dotnet_diagnostic.IDE0079.severity = silent
+
 dotnet_sort_system_directives_first = true
 
 dotnet_style_qualification_for_field = false:suggestion
@@ -34,6 +44,7 @@ dotnet_style_object_initializer = true:suggestion
 
 csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
 
 csharp_style_expression_bodied_constructors = false:none
 csharp_style_expression_bodied_methods = false:none
@@ -42,6 +53,8 @@ csharp_style_expression_bodied_operators = false:none
 csharp_style_expression_bodied_accessors = true:none
 csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_properties = true:none
+
+csharp_style_expression_bodied_local_functions = when_on_single_line:silent
 
 csharp_style_conditional_delegate_call = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <PropertyGroup>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
     <Authors>martin_costello</Authors>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)LondonTravel.Skill.ruleset</CodeAnalysisRuleSet>
@@ -13,6 +13,7 @@
     <Deterministic Condition=" '$(IsTestProject)' == '' ">true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateGitMetadata Condition=" '$(CI)' != '' and '$(GenerateGitMetadata)' == '' ">true</GenerateGitMetadata>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -20,7 +21,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon></PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -35,6 +35,10 @@
     <VersionPrefix>3.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);419;1570;1573;1574;1584;1591;SA0001;SA1602</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="System.Globalization" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,9 @@
 <Project>
   <ItemGroup>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.3" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.1" />
@@ -34,15 +38,11 @@
     <PackageVersion Include="Polly.RateLimiting" Version="8.3.1" />
     <PackageVersion Include="ReportGenerator" Version="5.2.4" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Text.Json" Version="8.0.3" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/src/LondonTravel.Skill/Intents/CommuteIntent.cs
+++ b/src/LondonTravel.Skill/Intents/CommuteIntent.cs
@@ -16,7 +16,6 @@ namespace MartinCostello.LondonTravel.Skill.Intents;
 /// </remarks>
 /// <param name="skillClient">The skill client to use.</param>
 /// <param name="tflClient">The TfL API client to use.</param>
-/// <param name="contextAccessor">The AWS Lambda context accessor to use.</param>
 /// <param name="config">The skill configuration to use.</param>
 /// <param name="logger">The logger to use.</param>
 internal sealed class CommuteIntent(
@@ -55,13 +54,13 @@ internal sealed class CommuteIntent(
 
     private async Task<SkillResponse> CommuteAsync(ICollection<string> favoriteLines)
     {
-        IList<Line> lines = await GetStatusesAsync(string.Join(',', favoriteLines));
+        var lines = await GetStatusesAsync(string.Join(',', favoriteLines));
 
         var paragraphs = new List<string>(lines.Count);
 
         bool hasMultipleStatuses = lines.Count > 1;
 
-        foreach (Line line in lines.OrderBy((p) => p.Name, StringComparer.Ordinal))
+        foreach (var line in lines.OrderBy((p) => p.Name, StringComparer.Ordinal))
         {
             string text = StatusIntent.GenerateResponse([line]);
 
@@ -84,7 +83,7 @@ internal sealed class CommuteIntent(
     {
         try
         {
-            SkillUserPreferences preferences = await skillClient.GetPreferencesAsync(accessToken);
+            var preferences = await skillClient.GetPreferencesAsync(accessToken);
             return preferences.FavoriteLines ?? [];
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)

--- a/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
+++ b/src/LondonTravel.Skill/Intents/DisruptionIntent.cs
@@ -71,6 +71,6 @@ internal sealed class DisruptionIntent(TflClient tflClient, SkillConfiguration c
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Order(StringComparer.OrdinalIgnoreCase);
 
-        return [..distinct];
+        return [.. distinct];
     }
 }

--- a/src/LondonTravel.Skill/Intents/StatusIntent.cs
+++ b/src/LondonTravel.Skill/Intents/StatusIntent.cs
@@ -22,7 +22,7 @@ internal sealed class StatusIntent(TflClient tflClient, SkillConfiguration confi
     {
         string? rawLineName = null;
 
-        if (intent.Slots?.TryGetValue("LINE", out Slot? slot) is true)
+        if (intent.Slots?.TryGetValue("LINE", out var slot) is true)
         {
             rawLineName = slot.Value;
         }
@@ -38,7 +38,7 @@ internal sealed class StatusIntent(TflClient tflClient, SkillConfiguration confi
         }
         else
         {
-            IList<Line> statuses = await GetStatusesAsync(id);
+            var statuses = await GetStatusesAsync(id);
 
             string cardTitle = Lines.ToCardTitle(statuses[0]?.Name ?? string.Empty);
             string text = GenerateResponse(statuses);
@@ -60,11 +60,11 @@ internal sealed class StatusIntent(TflClient tflClient, SkillConfiguration confi
     /// </returns>
     internal static string GenerateResponse(IList<Line> lines)
     {
-        Line line = lines[0];
+        var line = lines[0];
 
         if (line.LineStatuses.Count == 1)
         {
-            LineStatus lineStatus = line.LineStatuses[0];
+            var lineStatus = line.LineStatuses[0];
 
             bool includeDetail = !ShouldStatusUseCustomResponse(lineStatus.StatusSeverity);
 
@@ -163,7 +163,7 @@ internal sealed class StatusIntent(TflClient tflClient, SkillConfiguration confi
         else
         {
             Debug.Assert(
-                status.StatusSeverity == LineStatusSeverity.GoodService || status.StatusSeverity == LineStatusSeverity.NoIssues,
+                status.StatusSeverity is LineStatusSeverity.GoodService or LineStatusSeverity.NoIssues,
                 $"'{status.StatusSeverity}' is not supported for a summary response.");
 
             format = Strings.StatusIntentGoodServiceFormat;

--- a/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
@@ -140,6 +140,9 @@ public class CloudWatchLogsFixture(IMessageSink diagnosticMessageSink) : IAsyncL
                                 case "XRAY TraceId":
                                     entry.TraceId = parts[1];
                                     break;
+
+                                default:
+                                    break;
                             }
                         }
                     }

--- a/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
+++ b/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" />
     <PackageReference Include="AWSSDK.Lambda" />
-    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.TestUtilities" />
-    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" />


### PR DESCRIPTION
- Enable (almost) all built-in style analyzers.
- Fix new style warnings.
- Use global package references.
- Add reference trimmer analyzer.
