### PR TITLE
Simplify assertions

### DIFF
--- a/test/LondonTravel.Skill.Tests/AlexaFunctionTests.cs
+++ b/test/LondonTravel.Skill.Tests/AlexaFunctionTests.cs
@@ -84,8 +84,6 @@ public class AlexaFunctionTests(ITestOutputHelper outputHelper) : FunctionTests(
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
     }
 }

--- a/test/LondonTravel.Skill.Tests/CommuteTests.cs
+++ b/test/LondonTravel.Skill.Tests/CommuteTests.cs
@@ -30,9 +30,7 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>You need to link your account to be able to ask me about your commute.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>You need to link your account to be able to ask me about your commute.</speak>");
     }
 
     [Fact]
@@ -58,9 +56,7 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>It looks like you've disabled account linking. You need to re-link your account to be able to ask me about your commute.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>It looks like you've disabled account linking. You need to re-link your account to be able to ask me about your commute.</speak>");
     }
 
     [Fact]
@@ -82,9 +78,7 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
     }
 
     [Fact]
@@ -158,9 +152,7 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe(expectedSsml);
+        response.OutputSpeech.Ssml.ShouldBe(expectedSsml);
 
         response.Card.ShouldNotBeNull();
         var card = response.Card.ShouldBeOfType<StandardCard>();

--- a/test/LondonTravel.Skill.Tests/DisruptionTests.cs
+++ b/test/LondonTravel.Skill.Tests/DisruptionTests.cs
@@ -88,9 +88,7 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
     }
 
     private void AssertResponse(SkillResponse actual, string expectedSsml, string expectedCardContent)
@@ -101,9 +99,7 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe(expectedSsml);
+        response.OutputSpeech.Ssml.ShouldBe(expectedSsml);
 
         response.Card.ShouldNotBeNull();
         var card = response.Card.ShouldBeOfType<StandardCard>();

--- a/test/LondonTravel.Skill.Tests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.Tests/EndToEndTests.cs
@@ -45,9 +45,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Welcome to London Travel. You can ask me about disruption or for the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Welcome to London Travel. You can ask me about disruption or for the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>");
     }
 
     [xRetry.RetryFact]
@@ -77,9 +75,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Goodbye.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Goodbye.</speak>");
     }
 
     [xRetry.RetryFact]
@@ -112,9 +108,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
     }
 
     private async Task<SkillResponse> ProcessRequestAsync(SkillRequest request)

--- a/test/LondonTravel.Skill.Tests/HelpTests.cs
+++ b/test/LondonTravel.Skill.Tests/HelpTests.cs
@@ -28,8 +28,6 @@ public class HelpTests(ITestOutputHelper outputHelper) : FunctionTests(outputHel
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak><p>This skill allows you to check for the status of a specific line, or for disruption in general. You can ask about any London Underground line, London Overground, the Docklands Light Railway or the Elizabeth line.</p><p>Asking about disruption in general provides information about any lines that are currently experiencing issues, such as any delays or planned closures.</p><p>Asking for the status for a specific line provides a summary of the current service, such as whether there is a good service or if there are any delays.</p><p>If you link your account and setup your preferences in the London Travel website, you can ask about your commute to quickly find out the status of the lines you frequently use.</p></speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak><p>This skill allows you to check for the status of a specific line, or for disruption in general. You can ask about any London Underground line, London Overground, the Docklands Light Railway or the Elizabeth line.</p><p>Asking about disruption in general provides information about any lines that are currently experiencing issues, such as any delays or planned closures.</p><p>Asking for the status for a specific line provides a summary of the current service, such as whether there is a good service or if there are any delays.</p><p>If you link your account and setup your preferences in the London Travel website, you can ask about your commute to quickly find out the status of the lines you frequently use.</p></speak>");
     }
 }

--- a/test/LondonTravel.Skill.Tests/LaunchTests.cs
+++ b/test/LondonTravel.Skill.Tests/LaunchTests.cs
@@ -28,8 +28,6 @@ public class LaunchTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Welcome to London Travel. You can ask me about disruption or for the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Welcome to London Travel. You can ask me about disruption or for the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>");
     }
 }

--- a/test/LondonTravel.Skill.Tests/SessionEndedTests.cs
+++ b/test/LondonTravel.Skill.Tests/SessionEndedTests.cs
@@ -28,8 +28,6 @@ public class SessionEndedTests(ITestOutputHelper outputHelper) : FunctionTests(o
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Goodbye.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Goodbye.</speak>");
     }
 }

--- a/test/LondonTravel.Skill.Tests/StatusTests.cs
+++ b/test/LondonTravel.Skill.Tests/StatusTests.cs
@@ -89,9 +89,7 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
         foreach (var speech in speeches)
         {
             speech.Type.ShouldBe("SSML");
-
-            var ssml = speech.ShouldBeOfType<SsmlOutputSpeech>();
-            ssml.Ssml.ShouldBe("<speak>Sorry, I am not sure what line you said. You can ask about the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>");
+            speech.Ssml.ShouldBe("<speak>Sorry, I am not sure what line you said. You can ask about the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>");
         }
     }
 
@@ -114,9 +112,7 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Sorry, something went wrong.</speak>");
     }
 
     [Theory]
@@ -168,8 +164,7 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
 
         if (expectedSsml != null)
         {
-            var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-            ssml.Ssml.ShouldBe(expectedSsml);
+            response.OutputSpeech.Ssml.ShouldBe(expectedSsml);
         }
 
         response.Card.ShouldNotBeNull();

--- a/test/LondonTravel.Skill.Tests/UnknownIntentTests.cs
+++ b/test/LondonTravel.Skill.Tests/UnknownIntentTests.cs
@@ -28,8 +28,6 @@ public class UnknownIntentTests(ITestOutputHelper outputHelper) : FunctionTests(
 
         response.OutputSpeech.ShouldNotBeNull();
         response.OutputSpeech.Type.ShouldBe("SSML");
-
-        var ssml = response.OutputSpeech.ShouldBeOfType<SsmlOutputSpeech>();
-        ssml.Ssml.ShouldBe("<speak>Sorry, I don't understand how to do that.</speak>");
+        response.OutputSpeech.Ssml.ShouldBe("<speak>Sorry, I don't understand how to do that.</speak>");
     }
 }


### PR DESCRIPTION
Remove `ShouldBeOfType<T>()` assertions that aren't using a more derived type that the input.

I think these became redundant when the Alexa.NET dependency was removed to move to native AoT.