### PR TITLE
Refactoring to prepare to add native AoT tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,6 +27,7 @@
     <PackageProjectUrl>https://github.com/martincostello/alexa-london-travel</PackageProjectUrl>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PublishForAWSLambda>false</PublishForAWSLambda>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,9 +45,4 @@
     <Using Include="System.Globalization" />
     <Using Include="System.Text" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <Using Include="Shouldly" />
-    <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
-  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,8 +43,4 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -85,17 +85,12 @@ function DotNetTest {
 }
 
 function DotNetPublish {
-    param([string]$Project)
+    param([string]$Project, [bool]$PublishForAWSLambda = $false)
 
     $additionalArgs = @()
 
-    if ($IsLinux -And (-Not $UseManagedRuntime)) {
-        $additionalArgs += "--runtime"
-        $additionalArgs += "linux-arm64"
-        $additionalArgs += "--self-contained"
-        $additionalArgs += "true"
-        $additionalArgs += "/p:AssemblyName=bootstrap"
-        $additionalArgs += "/p:IlcInstructionSet=armv8.2-a"
+    if ($PublishForAWSLambda) {
+        $additionalArgs += "/p:PublishForAWSLambda=true"
     }
 
     & $dotnet publish $Project $additionalArgs
@@ -115,8 +110,9 @@ $publishProjects = @(
 )
 
 Write-Host "Publishing solution..." -ForegroundColor Green
+$publishForAWSLambda = $IsLinux -And (-Not $UseManagedRuntime)
 ForEach ($project in $publishProjects) {
-    DotNetPublish $project
+    DotNetPublish $project $publishForAWSLambda
 }
 
 Write-Host "Testing $($testProjects.Count) project(s)..." -ForegroundColor Green

--- a/src/LondonTravel.Skill/FunctionHandler.cs
+++ b/src/LondonTravel.Skill/FunctionHandler.cs
@@ -26,7 +26,7 @@ internal sealed class FunctionHandler(AlexaSkill skill, SkillConfiguration confi
     {
         VerifySkillId(request);
 
-        CultureInfo previousCulture = SetLocale(request);
+        var previousCulture = SetLocale(request);
 
         try
         {
@@ -49,26 +49,14 @@ internal sealed class FunctionHandler(AlexaSkill skill, SkillConfiguration confi
     {
         try
         {
-            if (request.Request.Type is RequestTypes.Launch)
+            return request.Request.Type switch
             {
-                return skill.OnLaunch(request.Session);
-            }
-            else if (request.Request.Type is RequestTypes.Intent)
-            {
-                return await skill.OnIntentAsync(request.Request, request.Session);
-            }
-            else if (request.Request.Type is RequestTypes.SessionEnded)
-            {
-                return skill.OnSessionEnded(request.Session);
-            }
-            else if (request.Request.Type is RequestTypes.SystemException)
-            {
-                return skill.OnError(request.Request, request.Session);
-            }
-            else
-            {
-                return skill.OnError(null as Exception, request.Session);
-            }
+                RequestTypes.Intent => await skill.OnIntentAsync(request.Request, request.Session),
+                RequestTypes.Launch => skill.OnLaunch(request.Session),
+                RequestTypes.SessionEnded => skill.OnSessionEnded(request.Session),
+                RequestTypes.SystemException => skill.OnError(request.Request, request.Session),
+                _ => skill.OnError(null as Exception, request.Session),
+            };
         }
 #pragma warning disable CA1031
         catch (Exception ex)

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -14,6 +14,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(PublishForAWSLambda)' == 'true' ">
+    <AssemblyName>bootstrap</AssemblyName>
+    <IlcInstructionSet>armv8.2-a</IlcInstructionSet>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" />
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />

--- a/src/LondonTravel.Skill/Models/Card.cs
+++ b/src/LondonTravel.Skill/Models/Card.cs
@@ -5,9 +5,11 @@ using System.Text.Json.Serialization;
 
 namespace MartinCostello.LondonTravel.Skill.Models;
 
-[JsonDerivedType(typeof(LinkAccountCard))]
-[JsonDerivedType(typeof(StandardCard))]
+[JsonDerivedType(typeof(LinkAccountCard), CardTypes.LinkAccount)]
+[JsonDerivedType(typeof(StandardCard), CardTypes.Standard)]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 public abstract class Card
 {
-    public abstract string Type { get; set; }
+    [JsonIgnore]
+    public abstract string Type { get; }
 }

--- a/src/LondonTravel.Skill/Models/CardTypes.cs
+++ b/src/LondonTravel.Skill/Models/CardTypes.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Martin Costello, 2017. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Text.Json.Serialization;
-
 namespace MartinCostello.LondonTravel.Skill.Models;
 
-public sealed class LinkAccountCard : Card
+public static class CardTypes
 {
-    [JsonIgnore]
-    public override string Type => CardTypes.LinkAccount;
+    public const string LinkAccount = "LinkAccount";
+    public const string Standard = "Standard";
 }

--- a/src/LondonTravel.Skill/Models/StandardCard.cs
+++ b/src/LondonTravel.Skill/Models/StandardCard.cs
@@ -7,9 +7,8 @@ namespace MartinCostello.LondonTravel.Skill.Models;
 
 public sealed class StandardCard : Card
 {
-    [JsonPropertyName("type")]
-    [JsonRequired]
-    public override string Type { get; set; } = "Standard";
+    [JsonIgnore]
+    public override string Type => CardTypes.Standard;
 
     [JsonPropertyName("title")]
     [JsonRequired]

--- a/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
+++ b/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
@@ -18,4 +18,9 @@
   <ItemGroup>
     <Content Include="xunit.runner.json;Payloads\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+  <ItemGroup>
+    <Using Include="Shouldly" />
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
 </Project>

--- a/test/LondonTravel.Skill.Tests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.Tests/EndToEndTests.cs
@@ -15,13 +15,13 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
     public async Task Alexa_Function_Can_Process_Intent_Request()
     {
         // Arrange
-        SkillRequest request = CreateIntentRequest("AMAZON.CancelIntent");
+        var request = CreateIntentRequest("AMAZON.CancelIntent");
 
         // Act
         var actual = await ProcessRequestAsync(request);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldBeNull();
         response.OutputSpeech.ShouldBeNull();
@@ -32,13 +32,13 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
     public async Task Alexa_Function_Can_Process_Launch_Request()
     {
         // Arrange
-        SkillRequest request = CreateRequest("LaunchRequest");
+        var request = CreateRequest("LaunchRequest");
 
         // Act
         var actual = await ProcessRequestAsync(request);
 
         // Assert
-        ResponseBody response = AssertResponse(actual, shouldEndSession: false);
+        var response = AssertResponse(actual, shouldEndSession: false);
 
         response.Card.ShouldBeNull();
         response.Reprompt.ShouldBeNull();
@@ -62,12 +62,12 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
             },
         };
 
-        SkillRequest request = CreateRequest("SessionEndedRequest", session);
+        var request = CreateRequest("SessionEndedRequest", session);
 
         // Act
         var actual = await ProcessRequestAsync(request);
 
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         // Assert
         response.Card.ShouldBeNull();
@@ -95,12 +95,12 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
             },
         };
 
-        SkillRequest request = CreateRequest("System.ExceptionEncountered", exception);
+        var request = CreateRequest("System.ExceptionEncountered", exception);
 
         // Act
         var actual = await ProcessRequestAsync(request);
 
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         // Assert
         response.Card.ShouldBeNull();
@@ -126,7 +126,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
 
         await server.StartAsync(cancellationTokenSource.Token);
 
-        LambdaTestContext context = await server.EnqueueAsync(json);
+        var context = await server.EnqueueAsync(json);
 
         // Queue a task to stop the Lambda function as soon as the response is processed
         _ = Task.Run(async () =>

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -11,11 +11,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.TestUtilities" />
+    <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xRetry" />
     <PackageReference Include="xunit" />
@@ -23,6 +25,11 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="testsettings.json;xunit.runner.json;Bundles\*.json;Samples\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Shouldly" />
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>


### PR DESCRIPTION
- Support polymorphic deserialization of the cards using System.Text.Json.
- Move publishing properties for AWS Lambda into the project file and enable with a single property override.
- Resolve IDE suggestions by using `var`.
- Refactor references to support adding a new test project that does not use xunit.
- Refactor code to use a switch expression.
