### PR TITLE
Add tests for native aot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="8.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.3.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OpenTelemetry" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />

--- a/LondonTravel.Skill.sln
+++ b/LondonTravel.Skill.sln
@@ -74,6 +74,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LondonTravel.Skill.EndToEndTests", "test\LondonTravel.Skill.EndToEndTests\LondonTravel.Skill.EndToEndTests.csproj", "{385B221D-16BF-4703-8105-C8622C188B1A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LondonTravel.Skill.NativeAotTests", "test\LondonTravel.Skill.NativeAotTests\LondonTravel.Skill.NativeAotTests.csproj", "{190897E1-65DA-47E5-B960-674057F0F8EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +94,10 @@ Global
 		{385B221D-16BF-4703-8105-C8622C188B1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{385B221D-16BF-4703-8105-C8622C188B1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{385B221D-16BF-4703-8105-C8622C188B1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{190897E1-65DA-47E5-B960-674057F0F8EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{190897E1-65DA-47E5-B960-674057F0F8EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{190897E1-65DA-47E5-B960-674057F0F8EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{190897E1-65DA-47E5-B960-674057F0F8EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -105,6 +111,7 @@ Global
 		{24473A89-5428-4E9E-8F55-661BBDBA8C31} = {27EF9EE1-288D-4AFD-9006-D7CE61B642DF}
 		{6F8B120B-EE10-459D-A59D-3FC0E8D59058} = {791C7C14-F862-41ED-9D92-12F844223C1B}
 		{385B221D-16BF-4703-8105-C8622C188B1A} = {27EF9EE1-288D-4AFD-9006-D7CE61B642DF}
+		{190897E1-65DA-47E5-B960-674057F0F8EF} = {27EF9EE1-288D-4AFD-9006-D7CE61B642DF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7E57D002-B20B-49BE-AD07-7FC61C2A764B}

--- a/build.ps1
+++ b/build.ps1
@@ -105,6 +105,10 @@ $testProjects = @(
     (Join-Path $solutionPath "test" "LondonTravel.Skill.EndToEndTests" "LondonTravel.Skill.EndToEndTests.csproj")
 )
 
+$testProjectsForAot = @(
+    (Join-Path $solutionPath "test" "LondonTravel.Skill.NativeAotTests" "LondonTravel.Skill.NativeAotTests.csproj")
+)
+
 $publishProjects = @(
     (Join-Path $solutionPath "src" "LondonTravel.Skill" "LondonTravel.Skill.csproj")
 )
@@ -118,4 +122,19 @@ ForEach ($project in $publishProjects) {
 Write-Host "Testing $($testProjects.Count) project(s)..." -ForegroundColor Green
 ForEach ($project in $testProjects) {
     DotNetTest $project
+}
+
+Write-Host "Testing $($testProjectsForAot.Count) project(s) for native AoT..." -ForegroundColor Green
+ForEach ($project in $testProjectsForAot) {
+    DotNetPublish $project
+
+    $projectName = [System.IO.Path]::GetDirectoryName($project)
+    $projectName = [System.IO.Path]::GetFileName($projectName)
+    $testBinary = (Join-Path $solutionPath "artifacts" "publish" $projectName $Configuration.ToLowerInvariant() $projectName)
+
+    & $testBinary
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Native AoT tests for $projectName failed with exit code $LASTEXITCODE"
+    }
 }

--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -1,0 +1,359 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using JustEat.HttpClientInterception;
+using MartinCostello.LondonTravel.Skill.Models;
+using MartinCostello.Testing.AwsLambdaTestServer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+[TestClass]
+public sealed class EndToEndTests
+{
+    private HttpClientInterceptorOptions Interceptor { get; } = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
+
+    [TestMethod]
+    [DataRow("AMAZON.CancelIntent")]
+    [DataRow("AMAZON.StopIntent")]
+    public async Task Alexa_Function_Can_Process_Intent_Request(string name)
+    {
+        // Arrange
+        var request = CreateIntentRequest(name);
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        // Assert
+        var response = AssertResponse(actual);
+
+        Assert.IsNull(response.Card);
+        Assert.IsNull(response.OutputSpeech);
+        Assert.IsNull(response.Reprompt);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_Intent_Request_For_Help()
+    {
+        // Arrange
+        var request = CreateIntentRequest("AMAZON.HelpIntent");
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        // Assert
+        var response = AssertResponse(actual, shouldEndSession: false);
+
+        Assert.IsNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("<speak><p>This skill allows you to check for the status of a specific line, or for disruption in general. You can ask about any London Underground line, London Overground, the Docklands Light Railway or the Elizabeth line.</p><p>Asking about disruption in general provides information about any lines that are currently experiencing issues, such as any delays or planned closures.</p><p>Asking for the status for a specific line provides a summary of the current service, such as whether there is a good service or if there are any delays.</p><p>If you link your account and setup your preferences in the London Travel website, you can ask about your commute to quickly find out the status of the lines you frequently use.</p></speak>", response.OutputSpeech.Ssml);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_Intent_Request_With_Unknown_Intent()
+    {
+        // Arrange
+        var request = CreateIntentRequest("FooIntent");
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        // Assert
+        var response = AssertResponse(actual, shouldEndSession: true);
+
+        Assert.IsNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("<speak>Sorry, I don't understand how to do that.</speak>", response.OutputSpeech.Ssml);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_Intent_Request_For_Disruption()
+    {
+        // Arrange
+        var request = CreateIntentRequest("DisruptionIntent");
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        // Assert
+        var response = AssertResponse(actual, shouldEndSession: true);
+
+        Assert.IsNotNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("<speak>There is currently no disruption on the tube, London Overground, the D.L.R. or the Elizabeth line.</speak>", response.OutputSpeech.Ssml);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_Intent_Request_For_Line_Status()
+    {
+        // Arrange
+        var request = CreateIntentRequest(
+            "StatusIntent",
+            new Slot() { Name = "LINE", Value = "Northern" });
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        // Assert
+        var response = AssertResponse(actual, shouldEndSession: true);
+
+        Assert.IsNotNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("<speak>There is a good service on the Northern line.</speak>", response.OutputSpeech.Ssml);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_Launch_Request()
+    {
+        // Arrange
+        var request = CreateRequest("LaunchRequest");
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        // Assert
+        var response = AssertResponse(actual, shouldEndSession: false);
+
+        Assert.IsNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
+        Assert.AreEqual("<speak>Welcome to London Travel. You can ask me about disruption or for the status of any tube line, London Overground, the D.L.R. or the Elizabeth line.</speak>", response.OutputSpeech.Ssml);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_Session_Ended_Request()
+    {
+        // Arrange
+        var session = new Request()
+        {
+            Reason = Reason.ExceededMaxReprompts,
+            Error = new()
+            {
+                Message = "Too many requests.",
+                Type = AlexaErrorType.RateLimitExceeded,
+            },
+        };
+
+        var request = CreateRequest("SessionEndedRequest", session);
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        var response = AssertResponse(actual);
+
+        // Assert
+        Assert.IsNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
+        Assert.AreEqual("<speak>Goodbye.</speak>", response.OutputSpeech.Ssml);
+    }
+
+    [TestMethod]
+    public async Task Alexa_Function_Can_Process_System_Exception_Request()
+    {
+        // Arrange
+        var exception = new Request()
+        {
+            Error = new()
+            {
+                Message = "An unknown error occurred.",
+                Type = AlexaErrorType.InternalServerError,
+            },
+            ErrorCause = new()
+            {
+                RequestId = "amzn1.echo-api.request.1234",
+            },
+        };
+
+        var request = CreateRequest("System.ExceptionEncountered", exception);
+
+        // Act
+        var actual = await ProcessRequestAsync(request);
+
+        var response = AssertResponse(actual);
+
+        // Assert
+        Assert.IsNull(response.Card);
+        Assert.IsNull(response.Reprompt);
+
+        Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
+        Assert.AreEqual("<speak>Sorry, something went wrong.</speak>", response.OutputSpeech.Ssml);
+    }
+
+    private static SkillRequest CreateIntentRequest(string name, params Slot[] slots)
+    {
+        var request = new Request()
+        {
+            Intent = new Intent()
+            {
+                Name = name,
+            },
+        };
+
+        if (slots.Length > 0)
+        {
+            request.Intent.Slots = [];
+
+            foreach (var slot in slots)
+            {
+                request.Intent.Slots[slot.Name] = slot;
+            }
+        }
+
+        return CreateRequest("IntentRequest", request);
+    }
+
+    private static SkillRequest CreateRequest(string type, Request? request = null)
+    {
+        var application = new Application()
+        {
+            ApplicationId = "my-skill-id",
+        };
+
+        var user = new User()
+        {
+            UserId = Guid.NewGuid().ToString(),
+        };
+
+        var result = new SkillRequest()
+        {
+            Context = new()
+            {
+                System = new()
+                {
+                    Application = application,
+                    Device = new()
+                    {
+                        SupportedInterfaces = new()
+                        {
+                            ["AudioPlayer"] = new(),
+                        },
+                    },
+                    User = user,
+                },
+            },
+            Request = request ?? new(),
+            Session = new()
+            {
+                Application = application,
+                Attributes = [],
+                New = true,
+                User = user,
+            },
+            Version = "1.0",
+        };
+
+        result.Request.Type = type;
+        result.Request.Locale = "en-GB";
+
+        return result;
+    }
+
+    private static ResponseBody AssertResponse(SkillResponse actual, bool? shouldEndSession = true)
+    {
+        Assert.IsNotNull(actual);
+        Assert.AreEqual("1.0", actual.Version);
+        Assert.IsNotNull(actual.Response);
+        Assert.AreEqual(shouldEndSession, actual.Response.ShouldEndSession);
+
+        return actual.Response;
+    }
+
+    private async Task<SkillResponse> ProcessRequestAsync(SkillRequest request)
+    {
+        // Arrange
+        string json = JsonSerializer.Serialize(request, AppJsonSerializerContext.Default.SkillRequest);
+
+        void Configure(IServiceCollection services)
+        {
+            services.AddLogging((builder) => builder.AddConsole());
+            services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
+                (_) => new HttpRequestInterceptionFilter(Interceptor));
+        }
+
+        using var server = new LambdaTestServer(Configure);
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        await server.StartAsync(cancellationTokenSource.Token);
+
+        var context = await server.EnqueueAsync(json);
+
+        // Queue a task to stop the Lambda function as soon as the response is processed
+        _ = Task.Run(async () =>
+        {
+            await context.Response.WaitToReadAsync(cancellationTokenSource.Token);
+
+            if (!cancellationTokenSource.IsCancellationRequested)
+            {
+                await cancellationTokenSource.CancelAsync();
+            }
+        });
+
+        using var httpClient = server.CreateClient();
+
+        // Act
+        await FunctionEntrypoint.RunAsync<TestAlexaFunction>(httpClient, cancellationTokenSource.Token);
+
+        // Assert
+        Assert.IsTrue(context.Response.TryRead(out var result));
+
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.IsSuccessful);
+        Assert.IsTrue(result.Duration > TimeSpan.Zero);
+        Assert.IsTrue(result.Duration <= TimeSpan.FromSeconds(2));
+        Assert.IsNotNull(result.Content);
+        Assert.AreNotEqual(0, result.Content.Length);
+
+        json = await result.ReadAsStringAsync();
+        var actual = JsonSerializer.Deserialize(json, AppJsonSerializerContext.Default.SkillResponse);
+
+        Assert.IsNotNull(actual);
+
+        return actual;
+    }
+
+    private sealed class TestAlexaFunction : AlexaFunction
+    {
+        protected override void Configure(ConfigurationBuilder builder)
+        {
+            base.Configure(builder);
+            builder.AddJsonFile("testsettings.json");
+        }
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddLogging((builder) => builder.AddConsole());
+            services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
+                (_) =>
+                {
+                    var options = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
+
+                    var type = typeof(EndToEndTests);
+                    var assembly = type.Assembly;
+
+                    using var disruption = assembly.GetManifestResourceStream($"{type.Namespace}.Bundles.tfl-no-disruptions.json")!;
+                    using var statuses = assembly.GetManifestResourceStream($"{type.Namespace}.Bundles.tfl-line-statuses.json")!;
+
+                    options.RegisterBundleFromStream(disruption);
+                    options.RegisterBundleFromStream(statuses);
+
+                    return new HttpRequestInterceptionFilter(options);
+                });
+
+            base.ConfigureServices(services);
+        }
+    }
+}

--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -339,16 +339,10 @@ public sealed class EndToEndTests
             services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
                 (_) =>
                 {
-                    var options = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
-
-                    var type = typeof(EndToEndTests);
-                    var assembly = type.Assembly;
-
-                    using var disruption = assembly.GetManifestResourceStream($"{type.Namespace}.Bundles.tfl-no-disruptions.json")!;
-                    using var statuses = assembly.GetManifestResourceStream($"{type.Namespace}.Bundles.tfl-line-statuses.json")!;
-
-                    options.RegisterBundleFromStream(disruption);
-                    options.RegisterBundleFromStream(statuses);
+                    var options = new HttpClientInterceptorOptions()
+                        .ThrowsOnMissingRegistration()
+                        .RegisterBundleFromResourceStream<EndToEndTests>("tfl-no-disruptions.json")
+                        .RegisterBundleFromResourceStream<EndToEndTests>("tfl-line-statuses.json");
 
                     return new HttpRequestInterceptionFilter(options);
                 });

--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -50,7 +50,9 @@ public sealed class EndToEndTests
 
         Assert.IsNull(response.Card);
         Assert.IsNull(response.Reprompt);
+
         Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
         Assert.AreEqual("<speak><p>This skill allows you to check for the status of a specific line, or for disruption in general. You can ask about any London Underground line, London Overground, the Docklands Light Railway or the Elizabeth line.</p><p>Asking about disruption in general provides information about any lines that are currently experiencing issues, such as any delays or planned closures.</p><p>Asking for the status for a specific line provides a summary of the current service, such as whether there is a good service or if there are any delays.</p><p>If you link your account and setup your preferences in the London Travel website, you can ask about your commute to quickly find out the status of the lines you frequently use.</p></speak>", response.OutputSpeech.Ssml);
     }
 
@@ -68,7 +70,9 @@ public sealed class EndToEndTests
 
         Assert.IsNull(response.Card);
         Assert.IsNull(response.Reprompt);
+
         Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
         Assert.AreEqual("<speak>Sorry, I don't understand how to do that.</speak>", response.OutputSpeech.Ssml);
     }
 
@@ -85,8 +89,11 @@ public sealed class EndToEndTests
         var response = AssertResponse(actual, shouldEndSession: true);
 
         Assert.IsNotNull(response.Card);
+        Assert.IsInstanceOfType<StandardCard>(response.Card);
         Assert.IsNull(response.Reprompt);
+
         Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
         Assert.AreEqual("<speak>There is currently no disruption on the tube, London Overground, the D.L.R. or the Elizabeth line.</speak>", response.OutputSpeech.Ssml);
     }
 
@@ -105,8 +112,11 @@ public sealed class EndToEndTests
         var response = AssertResponse(actual, shouldEndSession: true);
 
         Assert.IsNotNull(response.Card);
+        Assert.IsInstanceOfType<StandardCard>(response.Card);
         Assert.IsNull(response.Reprompt);
+
         Assert.IsNotNull(response.OutputSpeech);
+        Assert.AreEqual("SSML", response.OutputSpeech.Type);
         Assert.AreEqual("<speak>There is a good service on the Northern line.</speak>", response.OutputSpeech.Ssml);
     }
 

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="MSTest.Sdk/3.3.1">
+  <PropertyGroup>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
+    <PublishAot>!$([MSBuild]::ValueOrDefault('$(BuildingInsideVisualStudio)', 'false'))</PublishAot>
+    <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LondonTravel.Skill\LondonTravel.Skill.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="JustEat.HttpClientInterception" />
+    <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\LondonTravel.Skill.Tests\HttpRequestInterceptionFilter.cs" Link="HttpRequestInterceptionFilter.cs" />
+    <Content Include="..\LondonTravel.Skill.Tests\testsettings.json" Link="testsettings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <EmbeddedResource Include="..\LondonTravel.Skill.Tests\Bundles\*.json" LinkBase="Bundles" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+</Project>

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\LondonTravel.Skill.Tests\HttpClientInterceptorOptionsExtensions.cs" Link="HttpClientInterceptorOptionsExtensions.cs" />
     <Compile Include="..\LondonTravel.Skill.Tests\HttpRequestInterceptionFilter.cs" Link="HttpRequestInterceptionFilter.cs" />
     <Content Include="..\LondonTravel.Skill.Tests\testsettings.json" Link="testsettings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <EmbeddedResource Include="..\LondonTravel.Skill.Tests\Bundles\*.json" LinkBase="Bundles" />

--- a/test/LondonTravel.Skill.Tests/CommuteTests.cs
+++ b/test/LondonTravel.Skill.Tests/CommuteTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Amazon.Lambda.TestUtilities;
-using JustEat.HttpClientInterception;
 using MartinCostello.LondonTravel.Skill.Models;
 
 namespace MartinCostello.LondonTravel.Skill;
@@ -13,15 +12,15 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
     public async Task Can_Invoke_Function_When_The_Skill_Is_Not_Linked()
     {
         // Arrange
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequestWithToken(accessToken: null);
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequestWithToken(accessToken: null);
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldNotBeNull();
         response.Card.ShouldBeOfType<LinkAccountCard>();
@@ -37,17 +36,17 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
     public async Task Can_Invoke_Function_When_The_Skill_Token_Is_Invalid()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "skill-api-invalid-token.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("skill-api-invalid-token.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequestWithToken(accessToken: "invalid-access-token");
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequestWithToken(accessToken: "invalid-access-token");
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldNotBeNull();
         response.Card.ShouldBeOfType<LinkAccountCard>();
@@ -63,15 +62,15 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
     public async Task Can_Invoke_Function_When_The_Skill_Api_Fails()
     {
         // Arrange
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequestWithToken(accessToken: "random-access-token");
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequestWithToken(accessToken: "random-access-token");
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldBeNull();
         response.Reprompt.ShouldBeNull();
@@ -85,15 +84,15 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
     public async Task Can_Invoke_Function_When_The_Skill_Is_Linked_And_Has_No_Favorite_Lines()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "skill-api-no-favorites.json"));
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-line-statuses.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("skill-api-no-favorites.json");
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("tfl-line-statuses.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequestWithToken(accessToken: "token-for-no-favorites");
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequestWithToken(accessToken: "token-for-no-favorites");
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertResponse(
@@ -106,15 +105,15 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
     public async Task Can_Invoke_Function_When_The_Skill_Is_Linked_And_Has_One_Favorite_Line()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "skill-api-one-favorite.json"));
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-line-statuses.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("skill-api-one-favorite.json");
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("tfl-line-statuses.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequestWithToken(accessToken: "token-for-one-favorite");
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequestWithToken(accessToken: "token-for-one-favorite");
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertResponse(
@@ -127,15 +126,15 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
     public async Task Can_Invoke_Function_When_The_Skill_Is_Linked_And_Has_Two_Favorite_Lines()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "skill-api-two-favorites.json"));
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-line-statuses.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("skill-api-two-favorites.json");
+        await Interceptor.RegisterBundleFromResourceStreamAsync<CommuteTests>("tfl-line-statuses.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequestWithToken(accessToken: "token-for-two-favorites");
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequestWithToken(accessToken: "token-for-two-favorites");
         TestLambdaContext context = new();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertResponse(
@@ -146,7 +145,7 @@ public class CommuteTests(ITestOutputHelper outputHelper) : FunctionTests(output
 
     private void AssertResponse(SkillResponse actual, string expectedSsml, string expectedCardContent)
     {
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Reprompt.ShouldBeNull();
 

--- a/test/LondonTravel.Skill.Tests/DisruptionTests.cs
+++ b/test/LondonTravel.Skill.Tests/DisruptionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Amazon.Lambda.TestUtilities;
-using JustEat.HttpClientInterception;
 using MartinCostello.LondonTravel.Skill.Models;
 
 namespace MartinCostello.LondonTravel.Skill;
@@ -13,14 +12,14 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
     public async Task Can_Invoke_Function_When_There_Are_No_Disruptions()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-no-disruptions.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<DisruptionTests>("tfl-no-disruptions.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequest();
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequest();
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertResponse(
@@ -33,14 +32,14 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
     public async Task Can_Invoke_Function_When_There_Is_One_Disruption()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-one-disruption.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<DisruptionTests>("tfl-one-disruption.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequest();
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequest();
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertResponse(
@@ -53,14 +52,14 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
     public async Task Can_Invoke_Function_When_There_Are_Multiple_Disruptions()
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-multiple-disruptions.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<DisruptionTests>("tfl-multiple-disruptions.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequest();
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequest();
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertResponse(
@@ -73,15 +72,15 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
     public async Task Can_Invoke_Function_When_The_Api_Fails()
     {
         // Arrange
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentRequest();
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentRequest();
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldBeNull();
         response.Reprompt.ShouldBeNull();
@@ -93,7 +92,7 @@ public class DisruptionTests(ITestOutputHelper outputHelper) : FunctionTests(out
 
     private void AssertResponse(SkillResponse actual, string expectedSsml, string expectedCardContent)
     {
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Reprompt.ShouldBeNull();
 

--- a/test/LondonTravel.Skill.Tests/HttpClientInterceptorOptionsExtensions.cs
+++ b/test/LondonTravel.Skill.Tests/HttpClientInterceptorOptionsExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using JustEat.HttpClientInterception;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+internal static class HttpClientInterceptorOptionsExtensions
+{
+    public static HttpClientInterceptorOptions RegisterBundleFromResourceStream<T>(
+        this HttpClientInterceptorOptions options,
+        string name,
+        IEnumerable<KeyValuePair<string, string>>? templateValues = default)
+    {
+        using var stream = GetStream<T>(name);
+        return options.RegisterBundleFromStream(stream, templateValues);
+    }
+
+    public static async Task<HttpClientInterceptorOptions> RegisterBundleFromResourceStreamAsync<T>(
+        this HttpClientInterceptorOptions options,
+        string name,
+        IEnumerable<KeyValuePair<string, string>>? templateValues = default,
+        CancellationToken cancellationToken = default)
+    {
+        using var stream = GetStream<T>(name);
+        return await options.RegisterBundleFromStreamAsync(stream, templateValues, cancellationToken);
+    }
+
+    private static Stream GetStream<T>(string name)
+    {
+        var type = typeof(T);
+        var assembly = type.Assembly;
+        name = type.Namespace + ".Bundles." + name;
+
+        var stream = assembly.GetManifestResourceStream(name);
+
+        return stream ?? throw new ArgumentException($"The resource '{name}' was not found.", nameof(name));
+    }
+}

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -24,7 +24,8 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="testsettings.json;xunit.runner.json;Bundles\*.json;Samples\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="testsettings.json;xunit.runner.json;Samples\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="..\LondonTravel.Skill.Tests\Bundles\*.json" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Shouldly" />

--- a/test/LondonTravel.Skill.Tests/StatusTests.cs
+++ b/test/LondonTravel.Skill.Tests/StatusTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Amazon.Lambda.TestUtilities;
-using JustEat.HttpClientInterception;
 using MartinCostello.LondonTravel.Skill.Models;
 
 namespace MartinCostello.LondonTravel.Skill;
@@ -45,14 +44,14 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
     public async Task Can_Invoke_Function_For_Valid_Lines(string id)
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-line-statuses.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<StatusTests>("tfl-line-statuses.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentForLine(id);
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentForLine(id);
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertLineResponse(actual);
@@ -66,15 +65,15 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
     public async Task Can_Invoke_Function_For_Invalid_Line(string? id)
     {
         // Arrange
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentForLine(id);
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentForLine(id);
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldBeNull();
         response.OutputSpeech.ShouldNotBeNull();
@@ -97,15 +96,15 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
     public async Task Can_Invoke_Function_When_The_Api_Fails()
     {
         // Arrange
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentForLine("district");
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentForLine("district");
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Card.ShouldBeNull();
         response.Reprompt.ShouldBeNull();
@@ -136,14 +135,14 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
         string expected)
     {
         // Arrange
-        await Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "tfl-line-severities.json"));
+        await Interceptor.RegisterBundleFromResourceStreamAsync<StatusTests>("tfl-line-severities.json");
 
-        AlexaFunction function = await CreateFunctionAsync();
-        SkillRequest request = CreateIntentForLine(id);
-        TestLambdaContext context = new();
+        var function = await CreateFunctionAsync();
+        var request = CreateIntentForLine(id);
+        var context = new TestLambdaContext();
 
         // Act
-        SkillResponse actual = await function.HandlerAsync(request, context);
+        var actual = await function.HandlerAsync(request, context);
 
         // Assert
         AssertLineResponse(actual, expectedSsml: "<speak>" + expected + "</speak>");
@@ -155,7 +154,7 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
         string? expectedCardTitle = null,
         string? expectedCardContent = null)
     {
-        ResponseBody response = AssertResponse(actual);
+        var response = AssertResponse(actual);
 
         response.Reprompt.ShouldBeNull();
 


### PR DESCRIPTION
- Add end-to-end tests for native AoT.
- Extend test coverage for non-AoT tests.
- Load HTTP interception bundles from resources instead of from disk.
- Code style updates to use `var`.
