### PR TITLE
Add [Timeout] to AoT tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -15,9 +15,12 @@ namespace MartinCostello.LondonTravel.Skill;
 [TestClass]
 public sealed class EndToEndTests
 {
+    private const int TimeoutMilliseconds = 15_000;
+
     private HttpClientInterceptorOptions Interceptor { get; } = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     [DataRow("AMAZON.CancelIntent")]
     [DataRow("AMAZON.StopIntent")]
     public async Task Alexa_Function_Can_Process_Intent_Request(string name)
@@ -37,6 +40,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_Intent_Request_For_Help()
     {
         // Arrange
@@ -57,6 +61,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_Intent_Request_With_Unknown_Intent()
     {
         // Arrange
@@ -77,6 +82,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_Intent_Request_For_Disruption()
     {
         // Arrange
@@ -98,6 +104,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_Intent_Request_For_Line_Status()
     {
         // Arrange
@@ -121,6 +128,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_Launch_Request()
     {
         // Arrange
@@ -141,6 +149,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_Session_Ended_Request()
     {
         // Arrange
@@ -171,6 +180,7 @@ public sealed class EndToEndTests
     }
 
     [TestMethod]
+    [Timeout(TimeoutMilliseconds)]
     public async Task Alexa_Function_Can_Process_System_Exception_Request()
     {
         // Arrange


### PR DESCRIPTION
- Force AoT tests to timeout after 15 seconds if they deadlock/hang for some reason.
- Timeout build job after 20 minutes.
