### PR TITLE
Add MSTest.Sdk to global.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     awssdk:
       patterns:
         - AWSSDK*
+    mstest:
+      patterns:
+        - MSTest.Sdk
+        - MSTest.TestFramework
     opentelemetry:
       patterns:
         - OpenTelemetry*

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "8.0.204",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
+  },
+  "msbuild-sdks": {
+    "MSTest.Sdk": "3.3.1"
   }
 }

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk/3.3.1">
+<Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>


### PR DESCRIPTION
Use [MSBuild SDK in `global.json`](https://learn.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk#how-project-sdks-are-resolved) for the version of `MSTest.Sdk` so that dependabot can update it at the same time as `MSTest.TestFramework`.

See https://github.com/microsoft/testfx/issues/2703#issuecomment-2055979980.
