### PR TITLE
Bump System.Private.Uri

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <AnalysisMode>All</AnalysisMode>
     <Authors>martin_costello</Authors>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)LondonTravel.Skill.ruleset</CodeAnalysisRuleSet>
     <Company>https://github.com/martincostello/alexa-london-travel</Company>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Polly.RateLimiting" Version="8.4.0" />
     <PackageVersion Include="ReportGenerator" Version="5.3.6" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.3" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
     <PackageVersion Include="xunit" Version="2.8.1" />


### PR DESCRIPTION
Bump System.Private.Uri to resolve NuGet audit warnings for CVE-2019-0657, CVE-2019-0980 and CVE-2019-0981.
