### PR TITLE
Collect dump for hanging tests

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -71,7 +71,11 @@ if ($installDotNetSdk -eq $true) {
 function DotNetTest {
     param([string]$Project)
 
-    $additionalArgs = @()
+    $additionalArgs = @(
+      "--blame-hang",
+      "--blame-hang-timeout",
+      "60s"
+    )
 
     if (![string]::IsNullOrEmpty($env:GITHUB_SHA)) {
         $additionalArgs += "--logger"


### PR DESCRIPTION
Add `--blame-hang` for dotnet test to try and get to the bottom of why sometimes the Lambda tests deadlock and then eventually timeout.
