### PR TITLE
Collect hang dumps from native AoT tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="8.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="1.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="1.3.0-preview.24328.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OpenTelemetry" Version="1.8.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="8.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="1.2.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OpenTelemetry" Version="1.8.1" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,6 +6,9 @@
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="test-tools">
+      <package pattern="Microsoft.Testing.Extensions.HangDump" />
+    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,7 +7,7 @@
   </packageSources>
   <packageSourceMapping>
     <packageSource key="test-tools">
-      <package pattern="Microsoft.Testing.Extensions.HangDump" />
+      <package pattern="*" />
     </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />

--- a/build.ps1
+++ b/build.ps1
@@ -138,7 +138,15 @@ if (-Not $SkipTests) {
         $projectName = [System.IO.Path]::GetFileName($projectName)
         $testBinary = (Join-Path $solutionPath "artifacts" "publish" $projectName $Configuration.ToLowerInvariant() $projectName)
 
-        & $testBinary
+        $additionalArgs = @(
+            "--hangdump",
+            "--hangdump-filename",
+            "$projectName.${env:GITHUB_RUN_NUMBER}.${env:GITHUB_RUN_ATTEMPT}.hang.dmp",
+            "--hangdump-timeout",
+            "60s"
+        )
+
+        & $testBinary $additionalArgs
 
         if ($LASTEXITCODE -ne 0) {
             throw "Native AoT tests for $projectName failed with exit code $LASTEXITCODE"

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\LondonTravel.Skill.Tests\HttpClientInterceptorOptionsExtensions.cs" Link="HttpClientInterceptorOptionsExtensions.cs" />


### PR DESCRIPTION
Use [Microsoft.Testing.Extensions.HangDump](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-platform-extensions-diagnostics#hang-dump) to collect hang dumps from the native AoT tests too.

