### PR TITLE
Add linux-libc-dev:arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
         sudo sed -i -e 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
         sudo apt update
-        sudo apt install --yes clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
+        sudo apt install --yes clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu linux-libc-dev:arm64 zlib1g-dev:arm64
 
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
Fix installation of dependencies for native AoT compilation that seems to have started as of #1332.