### PR TITLE
Remove redundant PackageVersion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,6 @@ dotnet_diagnostic.IDE0058.severity = silent
 dotnet_diagnostic.IDE0072.severity = silent
 dotnet_diagnostic.IDE0079.severity = silent
 
-# HACK Workaround for https://github.com/dotnet/runtime/issues/100474
 dotnet_diagnostic.IL2026.severity = silent
 dotnet_diagnostic.IL3050.severity = silent
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="8.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.5.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />


### PR DESCRIPTION
- Remove redundant `PackageVersion` for MSTest.TestFramework.
- Remove redundant comment.
