### PR TITLE
Avoid deadlock in native AoT tests

### DIFF
--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <Compile Include="..\LondonTravel.Skill.Tests\HttpClientInterceptorOptionsExtensions.cs" Link="HttpClientInterceptorOptionsExtensions.cs" />
     <Compile Include="..\LondonTravel.Skill.Tests\HttpRequestInterceptionFilter.cs" Link="HttpRequestInterceptionFilter.cs" />
-    <Content Include="..\LondonTravel.Skill.Tests\testsettings.json" Link="testsettings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <EmbeddedResource Include="..\LondonTravel.Skill.Tests\Bundles\*.json" LinkBase="Bundles" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The deadlock appears to be coming from contention on the console on Linux when messages attempt to be written after the tests complete.

Avoid that by reducing the amount of console logs output from the tests.

See https://github.com/microsoft/testfx/issues/3485.