### PR TITLE
Use JSON polymorphism for end-to-end tests

### DIFF
--- a/test/LondonTravel.Skill.EndToEndTests/PlatformEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformEvent.cs
@@ -8,16 +8,20 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// <summary>
 /// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#telemetry-api-events.
 /// </summary>
-//// TODO Make polymorphic for .NET 9 with AllowOutOfOrderMetadataProperties = true
-////[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
-internal sealed class PlatformEvent
+[JsonDerivedType(typeof(PlatformExtensionEvent), PlatformEventType.Extension)]
+[JsonDerivedType(typeof(PlatformInitEvent), PlatformEventType.Initialize)]
+[JsonDerivedType(typeof(PlatformInitReportEvent), PlatformEventType.InitializeReport)]
+[JsonDerivedType(typeof(PlatformInitRuntimeDoneEvent), PlatformEventType.InitializeRuntimeDone)]
+[JsonDerivedType(typeof(PlatformReportEvent), PlatformEventType.Report)]
+[JsonDerivedType(typeof(PlatformRuntimeDoneEvent), PlatformEventType.RuntimeDone)]
+[JsonDerivedType(typeof(PlatformStartEvent), PlatformEventType.Start)]
+[JsonDerivedType(typeof(PlatformTelemetrySubscriptionEvent), PlatformEventType.TelemetrySubscription)]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+internal abstract class PlatformEvent
 {
     [JsonPropertyName("time")]
     public DateTime Timestamp { get; set; }
 
-    [JsonPropertyName("type")]
-    public string Type { get; set; } = default!;
-
-    [JsonPropertyName("record")]
-    public PlatformLogRecord? Record { get; set; }
+    [JsonIgnore]
+    public abstract string Type { get; }
 }

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformEventType.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformEventType.cs
@@ -8,9 +8,19 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal static class PlatformEventType
 {
+    public const string Extension = "platform.extension";
+
     public const string Initialize = "platform.initStart";
+
+    public const string InitializeReport = "platform.initReport";
+
+    public const string InitializeRuntimeDone = "platform.initRuntimeDone";
+
+    public const string Report = "platform.report";
+
+    public const string RuntimeDone = "platform.runtimeDone";
 
     public const string Start = "platform.start";
 
-    public const string Report = "platform.report";
+    public const string TelemetrySubscription = "platform.telemetrySubscription";
 }

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformExtensionEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformExtensionEvent.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-extension.
+/// </summary>
+internal sealed class PlatformExtensionEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.Extension;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-initStart.
+/// </summary>
+internal sealed class PlatformInitEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.Initialize;
+
+    [JsonPropertyName("record")]
+    public PlatformInitStart Record { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitReport.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitReport.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-initReport.
+/// </summary>
+internal sealed class PlatformInitReport
+{
+    [JsonPropertyName("errorType")]
+    public string? ErrorType { get; set; }
+
+    [JsonPropertyName("initializationType")]
+    public string InitializationType { get; set; } = default!;
+
+    [JsonPropertyName("phase")]
+    public string Phase { get; set; } = default!;
+
+    [JsonPropertyName("metrics")]
+    public PlatformReportMetrics Metrics { get; set; } = default!;
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitReportEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitReportEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-initReport.
+/// </summary>
+internal sealed class PlatformInitReportEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.InitializeReport;
+
+    [JsonPropertyName("record")]
+    public PlatformInitReport Record { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitRuntimeDone.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitRuntimeDone.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-initRuntimeDone.
+/// </summary>
+internal sealed class PlatformInitRuntimeDone
+{
+    [JsonPropertyName("initializationType")]
+    public string InitializationType { get; set; } = default!;
+
+    [JsonPropertyName("phase")]
+    public string Phase { get; set; } = default!;
+
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitRuntimeDoneEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitRuntimeDoneEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-initReport.
+/// </summary>
+internal sealed class PlatformInitRuntimeDoneEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.InitializeRuntimeDone;
+
+    [JsonPropertyName("record")]
+    public PlatformInitRuntimeDone Record { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitStart.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitStart.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-initStart.
+/// </summary>
+internal sealed class PlatformInitStart
+{
+    [JsonPropertyName("initializationType")]
+    public string InitializationType { get; set; } = default!;
+
+    [JsonPropertyName("phase")]
+    public string Phase { get; set; } = default!;
+
+    [JsonPropertyName("runtimeVersion")]
+    public string? RuntimeVersion { get; set; }
+
+    [JsonPropertyName("runtimeVersionArn")]
+    public string? RuntimeVersionArn { get; set; }
+
+    [JsonPropertyName("functionName")]
+    public string FunctionName { get; set; } = default!;
+
+    [JsonPropertyName("functionVersion")]
+    public string FunctionVersion { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformJsonSerializationContext.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformJsonSerializationContext.cs
@@ -6,5 +6,5 @@ using System.Text.Json.Serialization;
 namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 
 [JsonSerializable(typeof(PlatformEvent))]
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSourceGenerationOptions(AllowOutOfOrderMetadataProperties = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class PlatformJsonSerializationContext : JsonSerializerContext;

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformReport.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformReport.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-report.
+/// </summary>
+internal sealed class PlatformReport
+{
+    [JsonPropertyName("errorType")]
+    public string? ErrorType { get; set; }
+
+    [JsonPropertyName("requestId")]
+    public string RequestId { get; set; } = default!;
+
+    [JsonPropertyName("metrics")]
+    public PlatformReportMetrics Metrics { get; set; } = default!;
+
+    [JsonPropertyName("tracing")]
+    public PlatformTraceContext? Tracing { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformReportEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformReportEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-report.
+/// </summary>
+internal sealed class PlatformReportEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.Report;
+
+    [JsonPropertyName("record")]
+    public PlatformReport Record { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformRuntimeDoneEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformRuntimeDoneEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-runtimeDone.
+/// </summary>
+internal sealed class PlatformRuntimeDoneEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.RuntimeDone;
+
+    [JsonPropertyName("record")]
+    public PlatformReport Record { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformStart.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformStart.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-start.
+/// </summary>
+internal sealed class PlatformStart
+{
+    [JsonPropertyName("requestId")]
+    public string RequestId { get; set; } = default!;
+
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    [JsonPropertyName("tracing")]
+    public PlatformTraceContext? Tracing { get; set; }
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformStartEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformStartEvent.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-start.
+/// </summary>
+internal sealed class PlatformStartEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.Start;
+
+    [JsonPropertyName("record")]
+    public PlatformStart Record { get; set; } = default!;
+}

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformTelemetrySubscriptionEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformTelemetrySubscriptionEvent.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
+
+/// <summary>
+/// See https://docs.aws.amazon.com/lambda/latest/dg/telemetry-schema-reference.html#platform-telemetrySubscription.
+/// </summary>
+internal sealed class PlatformTelemetrySubscriptionEvent : PlatformEvent
+{
+    public override string Type => PlatformEventType.TelemetrySubscription;
+}


### PR DESCRIPTION
Use JSON polymorphism in the end-to-end tests to deserialize CloudWatch log entries.
