### PR TITLE
Remove SSL file no-op

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,7 +238,6 @@ jobs:
       run: |
         lambda_vars="{\
           \"Variables\": {\
-            \"SSL_CERT_FILE\": \"/tmp/noop\",\
             \"Skill__SkillApiUrl\": \"${SKILL_API_URL}\",\
             \"Skill__SkillId\": \"${SKILL_ID}\",\
             \"Skill__TflApplicationId\": \"${TFL_APPLICATION_ID}\",\


### PR DESCRIPTION
The need for this workaround should have been removed by upgrading to .NET 9. Let's find out.
<!-- Summarise the changes this Pull Request makes. -->

<!-- Please include a reference to a GitHub issue if appropriate. -->
