### PR TITLE
Remove SSL_CERT_FILE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,6 @@ jobs:
       run: |
         lambda_vars="{\
           \"Variables\": {\
-            \"SSL_CERT_FILE\": \"/tmp/noop\",\
             \"Skill__SkillApiUrl\": \"${SKILL_API_URL}\",\
             \"Skill__SkillId\": \"${SKILL_ID}\",\
             \"Skill__TflApplicationId\": \"${TFL_APPLICATION_ID}\",\
@@ -351,7 +350,6 @@ jobs:
       run: |
         lambda_vars="{\
           \"Variables\": {\
-            \"SSL_CERT_FILE\": \"/tmp/noop\",\
             \"Skill__SkillApiUrl\": \"${SKILL_API_URL}\",\
             \"Skill__SkillId\": \"${SKILL_ID}\",\
             \"Skill__TflApplicationId\": \"${TFL_APPLICATION_ID}\",\


### PR DESCRIPTION
The upgrade to .NET 9 should make the need to set this redundant.
<!-- Summarise the changes this Pull Request makes. -->

<!-- Please include a reference to a GitHub issue if appropriate. -->
