### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.11.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.3" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="3.7.402" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.402.3" />
+    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="3.7.403.11" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.405" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="4.3.0" />
@@ -33,14 +33,14 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.6" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.3.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.4.1" />
-    <PackageVersion Include="Polly.RateLimiting" Version="8.4.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.4.2" />
+    <PackageVersion Include="Polly.RateLimiting" Version="8.4.2" />
     <PackageVersion Include="ReportGenerator" Version="5.3.9" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
     <PackageVersion Include="xRetry" Version="1.9.0" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>


### PR DESCRIPTION
Update NuGet packages to their latest versions while dependabot does not support .NET 9.
