### PR TITLE
Fix workflow warning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5.0.7
       with:
-        file: ./artifacts/coverage/coverage.cobertura.xml
         flags: ${{ matrix.os_name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Remove deprecated `file` input for codecov/codecov-action.
