### PR TITLE
Remove London Overground

### DIFF
--- a/src/LondonTravel.Skill/Lines.cs
+++ b/src/LondonTravel.Skill/Lines.cs
@@ -35,18 +35,6 @@ internal static class Lines
     }
 
     /// <summary>
-    /// Returns whether the specified line name refers to the London Overground.
-    /// </summary>
-    /// <param name="name">The name of the line as reported from the TfL API.</param>
-    /// <returns>
-    /// A boolean indicating whether the line is the London Overground.
-    /// </returns>
-    public static bool IsOverground(string name)
-    {
-        return name.Contains("overground", StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
     /// Maps the specified line name to a TfL API line Id.
     /// </summary>
     /// <param name="line">The line name.</param>
@@ -69,29 +57,29 @@ internal static class Lines
             case "dlr":
             case "hammersmith-city":
             case "jubilee":
+            case "liberty":
+            case "lioness":
             case "london-overground":
             case "metropolitan":
+            case "mildmay":
             case "northern":
             case "piccadilly":
+            case "suffragette":
             case "tfl-rail":
             case "victoria":
             case "waterloo-city":
+            case "weaver":
+            case "windrush":
                 return normalized;
 
             case "crossrail":
             case "elizabeth":
             case "elizabeth line":
+            case "liz":
+            case "liz line":
+            case "lizzy":
+            case "lizzy line":
                 return "elizabeth";
-
-            case "london overground":
-            case "overground":
-            case "liberty":
-            case "lioness":
-            case "mildmay":
-            case "suffragette":
-            case "weaver":
-            case "windrush":
-                return "london-overground";
 
             case "met":
                 return "metropolitan";
@@ -114,6 +102,8 @@ internal static class Lines
             case "waterloo & city":
                 return "waterloo-city";
 
+            case "london overground":
+            case "overground":
             default:
                 return null;
         }
@@ -131,8 +121,7 @@ internal static class Lines
     {
         bool isNameWithoutLine =
             IsDlr(name) ||
-            IsElizabethLine(name) ||
-            IsOverground(name);
+            IsElizabethLine(name);
 
         string suffix = isNameWithoutLine ? Strings.LineSuffixUpper : string.Empty;
         return string.Format(CultureInfo.CurrentCulture, StatusIntentCardTitleFormat, name, suffix);

--- a/src/LondonTravel.Skill/Verbalizer.cs
+++ b/src/LondonTravel.Skill/Verbalizer.cs
@@ -21,27 +21,20 @@ internal static class Verbalizer
     /// </returns>
     internal static string LineName(string name, bool asTitleCase = false)
     {
-        string prefix = string.Empty;
+        string prefix = Strings.ThePrefix;
         string suffix = string.Empty;
         string spokenName;
 
         if (Lines.IsDlr(name))
         {
-            prefix = Strings.ThePrefix;
             spokenName = Verbalize("DLR");
         }
         else if (Lines.IsElizabethLine(name))
-        {
-            prefix = Strings.ThePrefix;
-            spokenName = name;
-        }
-        else if (Lines.IsOverground(name))
         {
             spokenName = name;
         }
         else
         {
-            prefix = Strings.ThePrefix;
             spokenName = name;
             suffix = asTitleCase ? Strings.LineSuffixUpper : Strings.LineSuffixLower;
         }

--- a/static/interaction-model.json
+++ b/static/interaction-model.json
@@ -875,7 +875,11 @@
                 "value": "elizabeth",
                 "synonyms": [
                   "crossrail",
-                  "elizabeth line"
+                  "elizabeth line",
+                  "liz",
+                  "liz line",
+                  "lizzie",
+                  "lizzie line"
                 ]
               }
             },
@@ -894,15 +898,19 @@
             },
             {
               "name": {
+                "value": "liberty"
+              }
+            },
+            {
+              "name": {
+                "value": "lioness"
+              }
+            },
+            {
+              "name": {
                 "value": "london overground",
                 "synonyms": [
-                  "liberty",
-                  "lioness",
-                  "overground",
-                  "mildmay",
-                  "suffragette",
-                  "weaver",
-                  "windrush"
+                  "overground"
                 ]
               }
             },
@@ -912,6 +920,11 @@
                 "synonyms": [
                   "met"
                 ]
+              }
+            },
+            {
+              "name": {
+                "value": "mildmay"
               }
             },
             {
@@ -926,6 +939,11 @@
             },
             {
               "name": {
+                "value": "suffragette"
+              }
+            },
+            {
+              "name": {
                 "value": "victoria"
               }
             },
@@ -936,6 +954,16 @@
                   "city",
                   "waterloo"
                 ]
+              }
+            },
+            {
+              "name": {
+                "value": "weaver"
+              }
+            },
+            {
+              "name": {
+                "value": "windrush"
               }
             }
           ]

--- a/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/SkillTests.cs
@@ -14,7 +14,6 @@ public class SkillTests(ITestOutputHelper outputHelper)
     [InlineData("Alexa, ask London Travel if there is any disruption today.")]
     [InlineData("Alexa, ask London Travel about the DLR.")]
     [InlineData("Alexa, ask London Travel about the Elizabeth line.")]
-    [InlineData("Alexa, ask London Travel about London Overground.")]
     [InlineData("Alexa, ask London Travel about the Victoria line.")]
     [InlineData("Alexa, ask London Travel about the Windrush line.")]
     public async Task Can_Invoke_Skill_And_Get_Valid_Response(string content)

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-line-severities.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-line-severities.json
@@ -349,13 +349,13 @@
       ]
     },
     {
-      "uri": "https://api.tfl.gov.uk/Line/london-overground/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "uri": "https://api.tfl.gov.uk/Line/liberty/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
       "contentFormat": "json",
       "contentJson": [
         {
           "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
-          "id": "london-overground",
-          "name": "London Overground",
+          "id": "liberty",
+          "name": "Liberty",
           "modeName": "overground",
           "disruptions": [],
           "created": "2019-10-17T12:58:58.107Z",
@@ -375,12 +375,53 @@
             {
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Regular",
-              "uri": "/Line/Route?ids=London Overground&serviceTypes=Regular"
+              "uri": "/Line/Route?ids=Liberty&serviceTypes=Regular"
             },
             {
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Night",
-              "uri": "/Line/Route?ids=London Overground&serviceTypes=Night"
+              "uri": "/Line/Route?ids=Liberty&serviceTypes=Night"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/lioness/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "lioness",
+          "name": "Lioness",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Lioness&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Lioness&serviceTypes=Night"
             }
           ],
           "crowding": {
@@ -417,6 +458,47 @@
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Regular",
               "uri": "/Line/Route?ids=Metropolitan&serviceTypes=Regular"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/mildmay/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "mildmay",
+          "name": "Mildmay",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Mildmay&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Mildmay&serviceTypes=Night"
             }
           ],
           "crowding": {
@@ -508,6 +590,47 @@
       ]
     },
     {
+      "uri": "https://api.tfl.gov.uk/Line/suffragette/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "suffragette",
+          "name": "Suffragette",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Suffragette&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Suffragette&serviceTypes=Night"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
       "uri": "https://api.tfl.gov.uk/Line/victoria/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
       "contentFormat": "json",
       "contentJson": [
@@ -576,6 +699,88 @@
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Regular",
               "uri": "/Line/Route?ids=Waterloo & City&serviceTypes=Regular"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/weaver/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "weaver",
+          "name": "Weaver",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Weaver&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Weaver&serviceTypes=Night"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/windrush/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "windrush",
+          "name": "Windrush",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Windrush&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Windrush&serviceTypes=Night"
             }
           ],
           "crowding": {

--- a/test/LondonTravel.Skill.Tests/Bundles/tfl-line-statuses.json
+++ b/test/LondonTravel.Skill.Tests/Bundles/tfl-line-statuses.json
@@ -380,13 +380,13 @@
       ]
     },
     {
-      "uri": "https://api.tfl.gov.uk/Line/london-overground/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "uri": "https://api.tfl.gov.uk/Line/liberty/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
       "contentFormat": "json",
       "contentJson": [
         {
           "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
-          "id": "london-overground",
-          "name": "London Overground",
+          "id": "liberty",
+          "name": "Liberty",
           "modeName": "overground",
           "disruptions": [],
           "created": "2019-10-17T12:58:58.107Z",
@@ -395,29 +395,10 @@
             {
               "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
               "id": 0,
-              "lineId": "london-overground",
-              "statusSeverity": 5,
-              "statusSeverityDescription": "Part Closure",
-              "reason": "LONDON OVERGROUND: Sunday 20 October, no service between Sydenham and Crystal Palace. Use local London Buses connections. Replacement buses also operate between Balham and West Croydon calling at Streatham Hill, West Norwood, Gipsy Hill, Crystal Palace, Norwood Junction and Selhurst.",
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
               "created": "0001-01-01T00:00:00",
-              "validityPeriods": [
-                {
-                  "$type": "Tfl.Api.Presentation.Entities.ValidityPeriod, Tfl.Api.Presentation.Entities",
-                  "fromDate": "2019-10-20T04:30:00Z",
-                  "toDate": "2019-10-21T01:29:00Z",
-                  "isNow": false
-                }
-              ],
-              "disruption": {
-                "$type": "Tfl.Api.Presentation.Entities.Disruption, Tfl.Api.Presentation.Entities",
-                "category": "PlannedWork",
-                "categoryDescription": "PlannedWork",
-                "description": "LONDON OVERGROUND: Sunday 20 October, no service between Sydenham and Crystal Palace. Use local London Buses connections. Replacement buses also operate between Balham and West Croydon calling at Streatham Hill, West Norwood, Gipsy Hill, Crystal Palace, Norwood Junction and Selhurst.",
-                "created": "2019-09-23T09:46:00Z",
-                "affectedRoutes": [],
-                "affectedStops": [],
-                "closureText": "partClosure"
-              }
+              "validityPeriods": []
             }
           ],
           "routeSections": [],
@@ -425,12 +406,53 @@
             {
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Regular",
-              "uri": "/Line/Route?ids=London Overground&serviceTypes=Regular"
+              "uri": "/Line/Route?ids=Liberty&serviceTypes=Regular"
             },
             {
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Night",
-              "uri": "/Line/Route?ids=London Overground&serviceTypes=Night"
+              "uri": "/Line/Route?ids=Liberty&serviceTypes=Night"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/lioness/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "lioness",
+          "name": "Lioness",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Lioness&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Lioness&serviceTypes=Night"
             }
           ],
           "crowding": {
@@ -467,6 +489,47 @@
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Regular",
               "uri": "/Line/Route?ids=Metropolitan&serviceTypes=Regular"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/mildmay/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "mildmay",
+          "name": "Mildmay",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Mildmay&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Mildmay&serviceTypes=Night"
             }
           ],
           "crowding": {
@@ -549,6 +612,47 @@
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Night",
               "uri": "/Line/Route?ids=Piccadilly&serviceTypes=Night"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/suffragette/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "suffragette",
+          "name": "Suffragette",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Suffragette&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Suffragette&serviceTypes=Night"
             }
           ],
           "crowding": {
@@ -644,6 +748,88 @@
               "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
               "name": "Regular",
               "uri": "/Line/Route?ids=Waterloo & City&serviceTypes=Regular"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/weaver/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "weaver",
+          "name": "Weaver",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Weaver&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Weaver&serviceTypes=Night"
+            }
+          ],
+          "crowding": {
+            "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+          }
+        }
+      ]
+    },
+    {
+      "uri": "https://api.tfl.gov.uk/Line/windrush/Status?app_id=my-tfl-app-id&app_key=my-tfl-app-key",
+      "contentFormat": "json",
+      "contentJson": [
+        {
+          "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+          "id": "windrush",
+          "name": "Windrush",
+          "modeName": "overground",
+          "disruptions": [],
+          "created": "2019-10-17T12:58:58.107Z",
+          "modified": "2019-10-17T12:58:58.107Z",
+          "lineStatuses": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+              "id": 0,
+              "statusSeverity": 10,
+              "statusSeverityDescription": "Good Service",
+              "created": "0001-01-01T00:00:00",
+              "validityPeriods": []
+            }
+          ],
+          "routeSections": [],
+          "serviceTypes": [
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Regular",
+              "uri": "/Line/Route?ids=Windrush&serviceTypes=Regular"
+            },
+            {
+              "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+              "name": "Night",
+              "uri": "/Line/Route?ids=Windrush&serviceTypes=Night"
             }
           ],
           "crowding": {

--- a/test/LondonTravel.Skill.Tests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.Tests/EndToEndTests.cs
@@ -97,7 +97,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
 
     [xRetry.RetryTheory(Timeout = TimeoutMilliseconds)]
     [InlineData("Northern", "There is a good service on the Northern line.")]
-    [InlineData("Windrush", "Sunday 20 October, no service between Sydenham and Crystal Palace. Use local London Buses connections. Replacement buses also operate between Balham and West Croydon calling at Streatham Hill, West Norwood, Gipsy Hill, Crystal Palace, Norwood Junction and Selhurst.")]
+    [InlineData("Windrush", "There is a good service on the Windrush line.")]
     public async Task Alexa_Function_Can_Process_Intent_Request_For_Line_Status(
         string line,
         string expected)

--- a/test/LondonTravel.Skill.Tests/InteractionModelTests.cs
+++ b/test/LondonTravel.Skill.Tests/InteractionModelTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+public static class InteractionModelTests
+{
+    [Fact]
+    public static async Task Interaction_Model_Is_Valid_Json()
+    {
+        // Arrange
+        var type = typeof(InteractionModelTests);
+        var assembly = type.Assembly;
+
+        using var model = assembly.GetManifestResourceStream(type.Namespace + ".interaction-model.json")!;
+        using var stream = new MemoryStream();
+
+        await model.CopyToAsync(stream);
+        model.Seek(0, SeekOrigin.Begin);
+
+        var reader = new Utf8JsonReader(stream.ToArray());
+
+        // Act
+        bool actual = JsonDocument.TryParseValue(ref reader, out _);
+
+        // Assert
+        actual.ShouldBeTrue();
+    }
+}

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="testsettings.json;xunit.runner.json;Samples\*.json" CopyToOutputDirectory="PreserveNewest" />
-    <EmbeddedResource Include="..\LondonTravel.Skill.Tests\Bundles\*.json" />
+    <EmbeddedResource Include="..\LondonTravel.Skill.Tests\Bundles\*.json;..\..\static\interaction-model.json" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Shouldly" />

--- a/test/LondonTravel.Skill.Tests/StatusTests.cs
+++ b/test/LondonTravel.Skill.Tests/StatusTests.cs
@@ -31,8 +31,6 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
     [InlineData("Jubilee")]
     [InlineData("Liberty")]
     [InlineData("Lioness")]
-    [InlineData("London Overground")]
-    [InlineData("Overground")]
     [InlineData("Met")]
     [InlineData("Metropolitan")]
     [InlineData("Mildmay")]
@@ -67,6 +65,8 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
     [InlineData("")]
     [InlineData("  ")]
     [InlineData("not a tube line")]
+    [InlineData("London Overground")]
+    [InlineData("Overground")]
     public async Task Can_Invoke_Function_For_Invalid_Line(string? id)
     {
         // Arrange
@@ -128,18 +128,17 @@ public class StatusTests(ITestOutputHelper outputHelper) : FunctionTests(outputH
     [InlineData("Elizabeth line", "There is a good service on the Elizabeth line.")]
     [InlineData("Hammersmith & City", "There is a good service on the Hammersmith and City line.")]
     [InlineData("Jubilee", "There is a good service on the Jubilee line.")]
-    [InlineData("Liberty", "There is a good service on London Overground.")]
-    [InlineData("Lioness", "There is a good service on London Overground.")]
-    [InlineData("London Overground", "There is a good service on London Overground.")]
+    [InlineData("Liberty", "There is a good service on the Liberty line.")]
+    [InlineData("Lioness", "There is a good service on the Lioness line.")]
     [InlineData("Metropolitan", "There is a good service on the Metropolitan line.")]
-    [InlineData("Mildmay", "There is a good service on London Overground.")]
+    [InlineData("Mildmay", "There is a good service on the Mildmay line.")]
     [InlineData("Northern", "There is a good service on the Northern line.")]
     [InlineData("Piccadilly", "There is a good service on the Piccadilly line.")]
-    [InlineData("Suffragette", "There is a good service on London Overground.")]
+    [InlineData("Suffragette", "There is a good service on the Suffragette line.")]
     [InlineData("Victoria", "There is a good service on the Victoria line.")]
     [InlineData("Waterloo & City", "There is a good service on the Waterloo and City line.")]
-    [InlineData("Weaver", "There is a good service on London Overground.")]
-    [InlineData("Windrush", "There is a good service on London Overground.")]
+    [InlineData("Weaver", "There is a good service on the Weaver line.")]
+    [InlineData("Windrush", "There is a good service on the Windrush line.")]
     public async Task Can_Invoke_Function_For_Different_Severities(
         string id,
         string expected)


### PR DESCRIPTION
- Remove "London Overground" and replace with the new rebranded individual lines.
- Add "liz" and "lizzy" as synonyms for the Elizabeth Line.
- Lint the interaction model is valid JSON.
