### PR TITLE
Update synonyms

### DIFF
--- a/static/interaction-model.json
+++ b/static/interaction-model.json
@@ -875,11 +875,8 @@
                 "value": "elizabeth",
                 "synonyms": [
                   "crossrail",
-                  "elizabeth line",
                   "liz",
-                  "liz line",
-                  "lizzie",
-                  "lizzie line"
+                  "lizzie"
                 ]
               }
             },


### PR DESCRIPTION
Remove the word "line" from the synonyms for the Elizabeth Line.
