### PR TITLE
Restore logging in Aot Tests

### DIFF
--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -299,7 +299,7 @@ public sealed class EndToEndTests
 
         void Configure(IServiceCollection services)
         {
-            services.AddLogging((builder) => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+            services.AddLogging((builder) => builder.AddConsole());
             services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
                 (_) => new HttpRequestInterceptionFilter(Interceptor));
         }
@@ -369,6 +369,7 @@ public sealed class EndToEndTests
 
         protected override void ConfigureServices(IServiceCollection services)
         {
+            services.AddLogging((builder) => builder.AddConsole());
             services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>((_) =>
             {
                 var options = new HttpClientInterceptorOptions()


### PR DESCRIPTION
Restore logging to native AoT tests.

See https://github.com/microsoft/testfx/issues/3485#issuecomment-2592278840.
