### PR TITLE
Refactor build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ permissions:
 
 jobs:
   build:
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os-name }}
+    runs-on: ${{ matrix.runnner }}
     timeout-minutes: 20
 
     permissions:
@@ -45,14 +45,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
         include:
-          - os: macos-latest
-            os_name: macos
-          - os: ubuntu-latest
-            os_name: linux
-          - os: windows-latest
-            os_name: windows
+          - os-name: macos
+            runnner: macos-latest
+          - os-name: linux
+            runnner: ubuntu-latest
+          - os-name: windows
+            runnner: windows-latest
 
     steps:
 
@@ -72,7 +71,7 @@ jobs:
 
         Types: deb
         URIs: http://security.ubuntu.com/ubuntu/
-        Suites: ${codename}-security 
+        Suites: ${codename}-security
         Components: main restricted universe
         Architectures: amd64
 
@@ -113,13 +112,13 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
       with:
-        flags: ${{ matrix.os_name }}
+        flags: ${{ matrix.os-name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Publish artifacts
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
-        name: artifacts-${{ matrix.os_name }}
+        name: artifacts-${{ matrix.os-name }}
         path: ./artifacts
 
     - name: Create Lambda ZIP file


### PR DESCRIPTION
- Prepare for using ARM64 runners by removing `-latest` from the job names (see #1553).
- Remove redundant item from matrix.
- Use hyphens instead of underscores for matrix item name.
