### PR TITLE
Moar telemetry

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -105,11 +105,14 @@ jobs:
 
     - name: Get Lambda function configuration
       shell: bash
+      env:
+        LAMBDA_LAYERS: ${{ vars.AWS_LAMBDA_LAYERS }}
       run: |
         LAMBDA_CONFIG="$(unzip -p "${ARCHIVE_NAME}.zip" aws-lambda-tools-defaults.json)"
         {
           echo "FUNCTION_ARCHITECTURES=$(echo "${LAMBDA_CONFIG}" | jq -r '."function-architecture"')"
           echo "FUNCTION_HANDLER=$(echo "${LAMBDA_CONFIG}" | jq -r '."function-handler"')"
+          echo "FUNCTION_LAYERS=$(echo "${LAMBDA_LAYERS}" | xargs)"
           echo "FUNCTION_MEMORY=$(echo "${LAMBDA_CONFIG}" | jq -r '."function-memory-size"')"
           echo "FUNCTION_RUNTIME=$(echo "${LAMBDA_CONFIG}" | jq -r '."function-runtime"')"
           echo "FUNCTION_TIMEOUT=$(echo "${LAMBDA_CONFIG}" | jq -r '."function-timeout"')"
@@ -117,6 +120,9 @@ jobs:
 
     - name: Get Lambda environment variables
       env:
+        OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT}}
+        OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS}}
+        OTEL_EXPORTER_OTLP_PROTOCOL: ${{ vars.OTEL_EXPORTER_OTLP_PROTOCOL}}
         SKILL_API_URL: ${{ vars.SKILL_API_URL }}
         SKILL_ID: ${{ secrets.SKILL_ID }}
         TFL_APPLICATION_ID: ${{ secrets.TFL_APPLICATION_ID }}
@@ -124,8 +130,14 @@ jobs:
         VERIFY_SKILL_ID: true
       shell: bash
       run: |
+        OTEL_EXPORTER_OTLP_ENDPOINT=$(echo "${OTEL_EXPORTER_OTLP_ENDPOINT}" | xargs)
+        OTEL_EXPORTER_OTLP_HEADERS=$(echo "${OTEL_EXPORTER_OTLP_HEADERS}" | xargs)
+        OTEL_EXPORTER_OTLP_PROTOCOL=$(echo "${OTEL_EXPORTER_OTLP_PROTOCOL}" | xargs)
         FUNCTION_ENVIRONMENT_VARIABLES="{\
           \"Variables\": {\
+            \"OTEL_EXPORTER_OTLP_ENDPOINT\": \"${OTEL_EXPORTER_OTLP_ENDPOINT}\",\
+            \"OTEL_EXPORTER_OTLP_HEADERS\": \"${OTEL_EXPORTER_OTLP_HEADERS}\",\
+            \"OTEL_EXPORTER_OTLP_PROTOCOL\": \"${OTEL_EXPORTER_OTLP_PROTOCOL}\",\
             \"Skill__SkillApiUrl\": \"${SKILL_API_URL}\",\
             \"Skill__SkillId\": \"${SKILL_ID}\",\
             \"Skill__TflApplicationId\": \"${TFL_APPLICATION_ID}\",\
@@ -158,7 +170,6 @@ jobs:
       shell: bash
       env:
         FUNCTION_DESCRIPTION: 'Deploy build #${{ inputs.artifact-run-number }} to AWS Lambda via GitHub Actions'
-        FUNCTION_LAYERS: ${{ vars.AWS_LAMBDA_LAYERS }}
         FUNCTION_LOGGING_CONFIG: ${{ vars.AWS_LAMBDA_LOGGING_CONFIG }}
         FUNCTION_ROLE: ${{ vars.AWS_LAMBDA_ROLE }}
         FUNCTION_TRACING_MODE: ${{ vars.AWS_TRACING_MODE }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.11.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.11.0-beta.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.5.2" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.5.2" />
     <PackageVersion Include="ReportGenerator" Version="5.4.4" />

--- a/src/LondonTravel.Skill/AlexaFunction.cs
+++ b/src/LondonTravel.Skill/AlexaFunction.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Logs;
 
 namespace MartinCostello.LondonTravel.Skill;
 
@@ -112,6 +113,19 @@ public class AlexaFunction : IAsyncDisposable, IDisposable
         {
             builder.AddConfiguration(configuration.GetSection("Logging"));
             builder.AddJsonConsole();
+
+            builder.AddOpenTelemetry((options) =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.IncludeScopes = true;
+
+                options.SetResourceBuilder(TelemetryExtensions.ResourceBuilder);
+
+                if (TelemetryExtensions.IsOtlpCollectorConfigured())
+                {
+                    options.AddOtlpExporter();
+                }
+            });
         });
 
         services.AddHttpClients();

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -40,6 +40,8 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" />
+    <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />
   </ItemGroup>


### PR DESCRIPTION
- Add operating system and process runtime resources.
- Refactor OpenTelemetry registration to be consistent with other applications.
- Separate AWS Lambda configuration from OpenTelemetry collector configuration.
- Log to the OpenTelemetry collector, if configured.
- Refactor deployment to support emitting metrics to an OLTP endpoint directly, rather than to a local collector in a layer.
