### PR TITLE
Fix missing telemetry

### DIFF
--- a/src/LondonTravel.Skill/AlexaFunction.cs
+++ b/src/LondonTravel.Skill/AlexaFunction.cs
@@ -130,7 +130,7 @@ public class AlexaFunction : IAsyncDisposable, IDisposable
 
                 options.SetResourceBuilder(TelemetryExtensions.ResourceBuilder);
 
-                if (TelemetryExtensions.IsOtlpCollectorConfigured())
+                if (IsRunningInAwsLambda())
                 {
                     options.AddOtlpExporter();
                 }

--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -34,12 +34,8 @@ internal static class TelemetryExtensions
 
                     if (AlexaFunction.IsRunningInAwsLambda())
                     {
-                        builder.AddAWSLambdaConfigurations();
-                    }
-
-                    if (IsOtlpCollectorConfigured())
-                    {
-                        builder.AddOtlpExporter();
+                        builder.AddAWSLambdaConfigurations()
+                               .AddOtlpExporter();
                     }
                 });
 
@@ -54,9 +50,6 @@ internal static class TelemetryExtensions
 
         return services;
     }
-
-    internal static bool IsOtlpCollectorConfigured()
-        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
 
     private static void EnrichHttpActivity(Activity activity, HttpRequestMessage request)
     {


### PR DESCRIPTION
Fix missing telemetry due to `OTEL_EXPORTER_OTLP_ENDPOINT` no longer being set in the environment variables.
