### PR TITLE
Fix telemetry configuration

### DIFF
--- a/src/LondonTravel.Skill/AlexaFunction.cs
+++ b/src/LondonTravel.Skill/AlexaFunction.cs
@@ -145,7 +145,7 @@ public class AlexaFunction : IAsyncDisposable, IDisposable
         services.AddSingleton<IntentFactory>();
         services.AddSingleton<IValidateOptions<SkillConfiguration>, ValidateSkillConfiguration>();
         services.AddSingleton((p) => p.GetRequiredService<IOptions<SkillConfiguration>>().Value);
-        services.AddSingleton(configuration);
+        services.AddSingleton<IConfiguration>(configuration);
 
         services.AddSingleton<EmptyIntent>();
         services.AddSingleton<HelpIntent>();

--- a/test/LondonTravel.Skill.Tests/AlexaFunctionTests.cs
+++ b/test/LondonTravel.Skill.Tests/AlexaFunctionTests.cs
@@ -9,7 +9,10 @@ using JustEat.HttpClientInterception;
 using MartinCostello.LondonTravel.Skill.Extensions;
 using MartinCostello.LondonTravel.Skill.Models;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
+using OpenTelemetry.Logs;
 
 namespace MartinCostello.LondonTravel.Skill;
 
@@ -100,7 +103,7 @@ public class AlexaFunctionTests(ITestOutputHelper outputHelper) : FunctionTests(
         // Arrange
         var secretsManager = Substitute.For<IAmazonSecretsManager>();
 
-        ConfigureSecret(secretsManager, "alexa-london-travel/OTEL_EXPORTER_OTLP_HEADERS", "Authorization secret-key");
+        ConfigureSecret(secretsManager, "alexa-london-travel/OTEL_EXPORTER_OTLP_HEADERS", $"Authorization=Basic secret-key");
         ConfigureSecret(secretsManager, "alexa-london-travel/Skill__SkillId", "secret-skill-id");
         ConfigureSecret(secretsManager, "alexa-london-travel/Skill__TflApplicationKey", "secret-tfl-app-id");
         ConfigureSecret(secretsManager, "alexa-london-travel/Skill__TflApplicationId", "secret-tfl-app-key");
@@ -152,6 +155,12 @@ public class AlexaFunctionTests(ITestOutputHelper outputHelper) : FunctionTests(
         {
             base.Configure(builder);
             builder.AddSecretsManager(cache);
+        }
+
+        protected override void ConfigureServices(IServiceCollection services)
+        {
+            base.ConfigureServices(services);
+            services.AddLogging((builder) => builder.AddOpenTelemetry((r) => r.AddOtlpExporter()));
         }
     }
 }


### PR DESCRIPTION
Fix `IConfigurationRoot` to replacing `IConfiguration` service registration, causing `IConfiguration` to not contain any values from AWS Secrets Manager.