### PR TITLE
Add Aspire AppHost

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     Amazon.Lambda:
       patterns:
         - Amazon.Lambda.*
+    Aspire:
+      patterns:
+        - Aspire.*
     AWSSDK:
       patterns:
         - AWSSDK*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,8 @@
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.12.3" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+    <PackageVersion Include="Aspire.Hosting.AWS" Version="9.1.4" />
     <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="3.7.409.40" />
     <PackageVersion Include="AWSSDK.Lambda" Version="3.7.411.47" />
     <PackageVersion Include="AWSSDK.SecretsManager" Version="3.7.400.104" />
@@ -22,6 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Http.Diagnostics" Version="9.2.0" />

--- a/LondonTravel.Skill.sln
+++ b/LondonTravel.Skill.sln
@@ -88,6 +88,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{C7B81695-4
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LondonTravel.Skill.Benchmarks", "perf\LondonTravel.Skill.Benchmarks\LondonTravel.Skill.Benchmarks.csproj", "{D5741BE6-0B73-43AB-AAC3-9F18427D7E06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LondonTravel.Skill.AppHost", "src\LondonTravel.Skill.AppHost\LondonTravel.Skill.AppHost.csproj", "{3983BA65-5884-E6F6-02DE-6533E574CBC0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +116,10 @@ Global
 		{D5741BE6-0B73-43AB-AAC3-9F18427D7E06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5741BE6-0B73-43AB-AAC3-9F18427D7E06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5741BE6-0B73-43AB-AAC3-9F18427D7E06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3983BA65-5884-E6F6-02DE-6533E574CBC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3983BA65-5884-E6F6-02DE-6533E574CBC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3983BA65-5884-E6F6-02DE-6533E574CBC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3983BA65-5884-E6F6-02DE-6533E574CBC0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -129,6 +135,7 @@ Global
 		{385B221D-16BF-4703-8105-C8622C188B1A} = {27EF9EE1-288D-4AFD-9006-D7CE61B642DF}
 		{190897E1-65DA-47E5-B960-674057F0F8EF} = {27EF9EE1-288D-4AFD-9006-D7CE61B642DF}
 		{D5741BE6-0B73-43AB-AAC3-9F18427D7E06} = {C7B81695-42DA-4416-B34C-6912DD089865}
+		{3983BA65-5884-E6F6-02DE-6533E574CBC0} = {8C59CF37-5860-4143-A891-A51E50620EBD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7E57D002-B20B-49BE-AD07-7FC61C2A764B}

--- a/global.json
+++ b/global.json
@@ -5,6 +5,7 @@
     "rollForward": "latestMajor"
   },
   "msbuild-sdks": {
+    "Aspire.AppHost.Sdk": "9.1.0",
     "MSTest.Sdk": "3.8.2"
   }
 }

--- a/src/LondonTravel.Skill.AppHost/LondonTravel.Skill.AppHost.csproj
+++ b/src/LondonTravel.Skill.AppHost/LondonTravel.Skill.AppHost.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" />
+  <PropertyGroup>
+    <IsAspireHost>true</IsAspireHost>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <UserSecretsId>LondonTravel.Skill.AppHost</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.AWS" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LondonTravel.Skill\LondonTravel.Skill.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/LondonTravel.Skill.AppHost/Program.cs
+++ b/src/LondonTravel.Skill.AppHost/Program.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+#pragma warning disable CA2252
+
+using Amazon;
+using Microsoft.Extensions.Configuration;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var aws = builder.AddAWSSDKConfig()
+                 .WithRegion(RegionEndpoint.EUWest1);
+
+var function = builder.AddAWSLambdaFunction<Projects.LondonTravel_Skill>("LondonTravelSkill", "LondonTravel.Skill")
+                      .WithReference(aws);
+
+string[] keys =
+[
+    "Skill:SkillApiUrl",
+    "Skill:TflApplicationId",
+    "Skill:TflApplicationKey",
+];
+
+foreach (string key in keys)
+{
+    string name = key.Replace(ConfigurationPath.KeyDelimiter, "__", StringComparison.Ordinal);
+    function.WithEnvironment(name, builder.Configuration[key]);
+}
+
+var app = builder.Build();
+
+app.Run();

--- a/src/LondonTravel.Skill.AppHost/Properties/launchSettings.json
+++ b/src/LondonTravel.Skill.AppHost/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "AppHost": {
+      "commandName": "Project",
+      "applicationUrl": "https://localhost:15294;http://localhost:15295",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16099",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    }
+  }
+}

--- a/src/LondonTravel.Skill.AppHost/appsettings.Development.json
+++ b/src/LondonTravel.Skill.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/LondonTravel.Skill.AppHost/appsettings.json
+++ b/src/LondonTravel.Skill.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Aspire.Hosting.Dcp": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -50,6 +50,6 @@
     <Compile Update="Strings.Designer.cs" AutoGen="True" DependentUpon="Strings.resx" DesignTime="True" />
     <EmbeddedResource Update="Strings.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Strings.Designer.cs" />
     <EmbeddedResource Update="Strings.*.resx" DependentUpon="Strings.resx" />
-    <None Include="appsettings.json;aws-lambda-tools-defaults.json" CopyToPublishDirectory="PreserveNewest" />
+    <None Include="appsettings.json;aws-lambda-tools-defaults.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add an Aspire AppHost to use for debugging the Lambda function locally.

See [_Building and Debugging .NET Lambda applications with .NET Aspire_](https://aws.amazon.com/blogs/developer/building-lambda-with-aspire-part-1/)