### PR TITLE
Fix option clobbering

### DIFF
--- a/src/LondonTravel.Skill/SecretsManagerConfigurationProvider.cs
+++ b/src/LondonTravel.Skill/SecretsManagerConfigurationProvider.cs
@@ -27,7 +27,7 @@ internal sealed class SecretsManagerConfigurationProvider(SecretsManagerCache ca
 
         foreach (string name in SecretNames)
         {
-            string key = name.Replace("__", ":");
+            string key = name.Replace("__", ConfigurationPath.KeyDelimiter, StringComparison.Ordinal);
             string value = await GetSecretAsync($"{Prefix}{name}", cancellationToken);
 
             if (value is { Length: > 0 })

--- a/src/LondonTravel.Skill/SecretsManagerConfigurationProvider.cs
+++ b/src/LondonTravel.Skill/SecretsManagerConfigurationProvider.cs
@@ -30,7 +30,10 @@ internal sealed class SecretsManagerConfigurationProvider(SecretsManagerCache ca
             string key = name.Replace("__", ":");
             string value = await GetSecretAsync($"{Prefix}{name}", cancellationToken);
 
-            secrets[key] = value;
+            if (value is { Length: > 0 })
+            {
+                secrets[key] = value;
+            }
         }
 
         Data = secrets;

--- a/src/LondonTravel.Skill/SkillResponseBuilder.cs
+++ b/src/LondonTravel.Skill/SkillResponseBuilder.cs
@@ -144,7 +144,7 @@ internal sealed class SkillResponseBuilder
                 return xmlString;
             }
 
-            int endOfSpeakTag = xmlString.IndexOf('>');
+            int endOfSpeakTag = xmlString.IndexOf('>', StringComparison.Ordinal);
             return string.Concat(SpeakTag, xmlString.AsSpan(endOfSpeakTag + 1));
         }
     }


### PR DESCRIPTION
- If the secrets in AWS Secrets Manager cannot be loaded, do not overwrite any configuration options that may have already been set through other means (e.g. environment variables or User Secrets).
- Fix analyzer warnings if invariant globalization is disabled.
- Use `ConfigurationPath.KeyDelimiter` instead of hard-coding `":"`.

Found via #1619.
