### PR TITLE
Avoid exception with Invariant Globalization

### DIFF
--- a/src/LondonTravel.Skill/CultureSwitcher.cs
+++ b/src/LondonTravel.Skill/CultureSwitcher.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.LondonTravel.Skill;
+
+internal sealed class CultureSwitcher : IDisposable
+{
+    private static readonly bool _invariant = IsGlobalizationInvariant();
+    private readonly CultureInfo? _previous;
+
+    private CultureSwitcher(string name)
+    {
+        _previous = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(name);
+        }
+        catch (ArgumentException)
+        {
+            // Ignore invalid/unknown cultures
+            _previous = null;
+        }
+    }
+
+    public static IDisposable UseCulture(string name)
+        => _invariant ? NullDisposable.Instance : new CultureSwitcher(name);
+
+    public void Dispose()
+    {
+        if (_previous is not null)
+        {
+            CultureInfo.CurrentCulture = _previous;
+        }
+    }
+
+    private static bool IsGlobalizationInvariant()
+    {
+        // Based on https://www.meziantou.net/detect-globalization-invariant-mode-in-dotnet.htm
+        if (AppContext.TryGetSwitch("System.Globalization.Invariant", out bool isEnabled) && isEnabled)
+        {
+            return true;
+        }
+
+        if (Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") is { Length: > 0 } value &&
+            (string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase) || value is "1"))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        internal static readonly NullDisposable Instance = new();
+
+        public void Dispose()
+        {
+            // No-op
+        }
+    }
+}

--- a/src/LondonTravel.Skill/FunctionHandler.cs
+++ b/src/LondonTravel.Skill/FunctionHandler.cs
@@ -26,15 +26,9 @@ internal sealed class FunctionHandler(AlexaSkill skill, SkillConfiguration confi
     {
         VerifySkillId(request);
 
-        var previousCulture = SetLocale(request);
-
-        try
+        using (CultureSwitcher.UseCulture(request.Request.Locale ?? "en-GB"))
         {
             return await HandleRequestAsync(request);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = previousCulture;
         }
     }
 
@@ -64,29 +58,6 @@ internal sealed class FunctionHandler(AlexaSkill skill, SkillConfiguration confi
         {
             return skill.OnError(ex, request.Session, request.Request.Type);
         }
-    }
-
-    /// <summary>
-    /// Sets the locale to use for resources for the current request.
-    /// </summary>
-    /// <param name="request">The skill request to use to set the locale.</param>
-    /// <returns>
-    /// The previous locale.
-    /// </returns>
-    private CultureInfo SetLocale(SkillRequest request)
-    {
-        var previousCulture = CultureInfo.CurrentCulture;
-
-        try
-        {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(request.Request.Locale ?? "en-GB");
-        }
-        catch (ArgumentException)
-        {
-            // Ignore invalid/unknown cultures
-        }
-
-        return previousCulture;
     }
 
     /// <summary>


### PR DESCRIPTION
Avoid an exception being thrown for every request when running with Invariant Globalization enabled by checking whether it is enabled and no-op-ing the change of culture if it is.
