### PR TITLE
Disable console logs in AoT tests

### DIFF
--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -299,7 +299,7 @@ public sealed class EndToEndTests
 
         void Configure(IServiceCollection services)
         {
-            services.AddLogging((builder) => builder.AddConsole());
+            services.AddLogging((builder) => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
             services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
                 (_) => new HttpRequestInterceptionFilter(Interceptor));
         }
@@ -369,7 +369,6 @@ public sealed class EndToEndTests
 
         protected override void ConfigureServices(IServiceCollection services)
         {
-            services.AddLogging((builder) => builder.AddConsole());
             services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>((_) =>
             {
                 var options = new HttpClientInterceptorOptions()


### PR DESCRIPTION
Revert re-enablement from #1551 as the issue seems to have come back.
