### PR TITLE
Use Microsoft Testing Platform

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -299,7 +299,7 @@ jobs:
         role-to-assume: ${{ secrets.AWS_DEPLOYMENT_ROLE_TEST }}
 
     - name: Run end-to-end tests
-      run: dotnet test ./test/LondonTravel.Skill.EndToEndTests --configuration Release --logger "GitHubActions;report-warnings=false"
+      run: dotnet test --project ./test/LondonTravel.Skill.EndToEndTests --configuration Release --logger "GitHubActions;report-warnings=false"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         LAMBDA_FUNCTION_NAME: ${{ env.FUNCTION_NAME }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -299,7 +299,7 @@ jobs:
         role-to-assume: ${{ secrets.AWS_DEPLOYMENT_ROLE_TEST }}
 
     - name: Run end-to-end tests
-      run: dotnet test --project ./test/LondonTravel.Skill.EndToEndTests --configuration Release --logger "GitHubActions;report-warnings=false"
+      run: dotnet test --project ./test/LondonTravel.Skill.EndToEndTests --configuration Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         LAMBDA_FUNCTION_NAME: ${{ env.FUNCTION_NAME }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,9 +17,7 @@
     <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.3.1" />
     <PackageVersion Include="AWSSDK.SecretsManager.Caching" Version="2.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.7" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.0" />
-    <PackageVersion Include="JunitXml.TestLogger" Version="7.0.2" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.2" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.0" />
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.12.0" />
@@ -35,6 +33,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.0.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
@@ -50,6 +50,6 @@
     <PackageVersion Include="ReportGenerator" Version="5.5.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.0" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.1.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/build.ps1
+++ b/build.ps1
@@ -73,11 +73,13 @@ function DotNetTest {
     $additionalArgs = @()
 
     if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
-        $additionalArgs += "--logger:GitHubActions;report-warnings=false"
-        $additionalArgs += "--logger:junit;LogFilePath=junit.xml"
-        $additionalArgs += "--blame-hang"
-        $additionalArgs += "--blame-hang-timeout"
+        $additionalArgs += "--hangdump"
+        $additionalArgs += "--hangdump-timeout"
         $additionalArgs += "180s"
+        $additionalArgs += "--report-github"
+        $additionalArgs += "--report-junit"
+        $additionalArgs += "--report-junit-filename"
+        $additionalArgs += "$([System.IO.Path]::GetFileNameWithoutExtension($Project)).junit.xml"
     }
 
     # HACK Workaround for https://github.com/dotnet/aspire/issues/7935
@@ -86,7 +88,7 @@ function DotNetTest {
         $config = "Debug"
     }
 
-    & $dotnet test $Project --configuration $config $additionalArgs
+    & $dotnet test --project $Project --configuration $config $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code ${LASTEXITCODE}"

--- a/build.ps1
+++ b/build.ps1
@@ -76,7 +76,6 @@ function DotNetTest {
         $additionalArgs += "--hangdump"
         $additionalArgs += "--hangdump-timeout"
         $additionalArgs += "180s"
-        $additionalArgs += "--report-github"
         $additionalArgs += "--report-junit"
         $additionalArgs += "--report-junit-filename"
         $additionalArgs += "$([System.IO.Path]::GetFileNameWithoutExtension($Project)).junit.xml"

--- a/build.ps1
+++ b/build.ps1
@@ -81,7 +81,7 @@ function DotNetTest {
         $additionalArgs += "$([System.IO.Path]::GetFileNameWithoutExtension($Project)).junit.xml"
     }
 
-    & $dotnet test --project $Project --configuration $config $additionalArgs
+    & $dotnet test --project $Project --configuration $Configuration $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code ${LASTEXITCODE}"

--- a/global.json
+++ b/global.json
@@ -12,5 +12,8 @@
   "msbuild-sdks": {
     "Aspire.AppHost.Sdk": "13.0.0",
     "MSTest.Sdk": "4.0.2"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/test/LondonTravel.Skill.AppHostTests/LondonTravel.Skill.AppHostTests.csproj
+++ b/test/LondonTravel.Skill.AppHostTests/LondonTravel.Skill.AppHostTests.csproj
@@ -12,15 +12,15 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="AWSSDK.Lambda" />
-    <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
-    <PackageReference Include="JunitXml.TestLogger" NoWarn="RT0003" />
+    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="MartinCostello.Logging.XUnit.v3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit.v3.mtp-off" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\LondonTravel.Skill.Tests\CategoryAttribute.cs" Link="CategoryAttribute.cs" />
@@ -29,10 +29,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
+    <CoverageRunSettings>$(MSBuildThisFileDirectory)tests.runsettings</CoverageRunSettings>
     <Threshold>100</Threshold>
   </PropertyGroup>
-  <ItemGroup>
-    <CoverletExclude Include="$([MSBuild]::Escape('[Amazon.Lambda*]*'))" />
-    <CoverletExclude Include="$([MSBuild]::Escape('[LondonTravel.Skill]*'))" />
-  </ItemGroup>
 </Project>

--- a/test/LondonTravel.Skill.AppHostTests/tests.runsettings
+++ b/test/LondonTravel.Skill.AppHostTests/tests.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+    <ModulePaths>
+      <Exclude>
+        <ModulePath>.*\\obj\\.*</ModulePath>
+        <ModulePath>.*\/obj\/.*</ModulePath>
+        <ModulePath>.*LondonTravel.Skill.dll</ModulePath>
+      </Exclude>
+    </ModulePaths>
+  </CodeCoverage>
+</Configuration>

--- a/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
+++ b/test/LondonTravel.Skill.EndToEndTests/LondonTravel.Skill.EndToEndTests.csproj
@@ -8,12 +8,12 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatchLogs" />
     <PackageReference Include="AWSSDK.Lambda" />
-    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
-    <PackageReference Include="JunitXml.TestLogger" NoWarn="RT0003" />
+    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit.v3.mtp-off" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\LondonTravel.Skill.Tests\CategoryAttribute.cs" Link="CategoryAttribute.cs" />

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -12,18 +12,18 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" />
-    <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
-    <PackageReference Include="JunitXml.TestLogger" NoWarn="RT0003" />
+    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit.v3" />
     <PackageReference Include="MartinCostello.Testing.AwsLambdaTestServer" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit.v3.mtp-off" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="testsettings.json;Samples\*.json" CopyToOutputDirectory="PreserveNewest" />
@@ -31,9 +31,6 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <Threshold>95,87,95</Threshold>
+    <Threshold>95,74</Threshold>
   </PropertyGroup>
-  <ItemGroup>
-    <CoverletExclude Include="$([MSBuild]::Escape('[Amazon.Lambda*]*'))" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Migrate to [Microsoft Testing Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)

Missing features:

- [x] ~~GitHub Actions summaries (see https://github.com/Tyrrrz/GitHubActionsTestLogger/issues/41)~~
- [x] ~~Fail if coverage is too low (see https://github.com/microsoft/codecoverage/issues/160)~~ - mitigated with custom target, but still preferable to delegate to something else
- [x] ~~Test failures not printed to the console (see https://github.com/microsoft/testfx/issues/5188)~~
- [ ] Coverage reports not being generated (see https://github.com/microsoft/testfx/issues/6719)
- [x] ~~GitHubActionsTestLogger throws exception (see https://github.com/Tyrrrz/GitHubActionsTestLogger/issues/41#issuecomment-3566684561)~~
