### PR TITLE
Refactor code coverage

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,22 +19,61 @@
     </ItemGroup>
   </Target>
   <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">
-    <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
-    <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
-    <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
-    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
+    <_CoveragePath>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</_CoveragePath>
+    <_ReportGeneratorOutputMarkdown Condition=" '$(GITHUB_SHA)' != '' ">true</_ReportGeneratorOutputMarkdown>
+    <_ReportGeneratorReportTypes>HTML</_ReportGeneratorReportTypes>
+    <_ReportGeneratorReportTypes Condition=" '$(_ReportGeneratorOutputMarkdown)' == 'true' ">$(_ReportGeneratorReportTypes);MarkdownSummaryGitHub</_ReportGeneratorReportTypes>
+    <_ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</_ReportGeneratorTargetDirectory>
+    <CoverletOutput>$([System.IO.Path]::Combine($(_CoveragePath), '$(MSBuildProjectName)', 'coverage'))</CoverletOutput>
+    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
   </PropertyGroup>
+  <UsingTask TaskName="WriteLinesToFileWithRetry" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <File ParameterType="System.String" Required="true" />
+      <Lines ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        var lines = new System.Collections.Generic.List<string>();
+        foreach (var line in Lines)
+        {
+            lines.Add(line.ItemSpec);
+        }
+        int attempt = 0;
+        while (attempt < 3)
+        {
+            try
+            {
+                System.IO.File.WriteAllLines(File, lines);
+                break;
+            }
+            catch (System.IO.IOException)
+            {
+                attempt++;
+                System.Threading.Thread.Sleep(1_000);
+            }
+        }
+   ]]></Code>
+    </Task>
+  </UsingTask>
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
-    <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
-    <PropertyGroup Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">
+    <ItemGroup>
+      <_CoverageReports Include="$(_CoveragePath)\**\coverage.cobertura.xml" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_CoverageGitHubSummary>$([System.IO.Path]::Combine($(_ReportGeneratorTargetDirectory), 'SummaryGithub.md'))</_CoverageGitHubSummary>
+    </PropertyGroup>
+    <ReportGenerator Condition=" '@(_CoverageReports->Count())' &gt; 0 " ReportFiles="@(_CoverageReports)" ReportTypes="$(_ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(_ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
+    <PropertyGroup Condition=" '$(_ReportGeneratorOutputMarkdown)' == 'true' AND Exists('$(_CoverageGitHubSummary)') ">
       <_ReportSummaryContent>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
-      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.IO.File]::ReadAllText('$(_CoverageGitHubSummary)'))</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)&lt;/details&gt;</_ReportSummaryContent>
     </PropertyGroup>
-    <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
+    <WriteLinesToFileWithRetry Condition=" '$(_ReportGeneratorOutputMarkdown)' == 'true' AND Exists('$(_CoverageGitHubSummary)') " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
   </Target>
 </Project>

--- a/test/LondonTravel.Skill.AppHostTests/LondonTravel.Skill.AppHostTests.csproj
+++ b/test/LondonTravel.Skill.AppHostTests/LondonTravel.Skill.AppHostTests.csproj
@@ -12,9 +12,11 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" />
     <PackageReference Include="AWSSDK.Lambda" />
+    <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="GitHubActionsTestLogger" NoWarn="RT0003" />
     <PackageReference Include="MartinCostello.Logging.XUnit.v3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="ReportGenerator" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.v3" />
@@ -28,4 +30,9 @@
     <Using Include="Shouldly" />
     <Using Include="Xunit" />
   </ItemGroup>
+  <PropertyGroup>
+    <CollectCoverage>true</CollectCoverage>
+    <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[LondonTravel.Skill]*,[xunit.*]*</Exclude>
+    <Threshold>100</Threshold>
+  </PropertyGroup>
 </Project>

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -35,10 +35,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
-    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
-    <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[LondonTravel.Skill.EndToEndTests]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+    <Exclude>[Alexa.NET*]*,[Amazon.Lambda*]*,[xunit.*]*</Exclude>
     <Threshold>86</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Cherry-pick changes from #1629 to:

- Centralise more coverage logic.
- Make writing the coverage to the step summary more resilient.
- Simplify coverage exclusions.
- Collect coverage from the Aspire app host.
