### PR TITLE
Avoid deadlock

### DIFF
--- a/test/LondonTravel.Skill.AppHostTests/LambdaFunctionFixture.cs
+++ b/test/LondonTravel.Skill.AppHostTests/LambdaFunctionFixture.cs
@@ -78,7 +78,12 @@ public sealed class LambdaFunctionFixture : IAsyncLifetime, ITestOutputHelperAcc
         => await InitializeAsync(TestContext.Current.CancellationToken);
 
     private void ConfigureServices(IServiceCollection services)
-        => services.AddLogging((p) => p.AddXUnit(this).SetMinimumLevel(LogLevel.Warning));
+        => services.AddLogging((builder) =>
+        {
+            builder.ClearProviders()
+                   .AddXUnit(this)
+                   .SetMinimumLevel(LogLevel.Warning);
+        });
 
     private void AddHttpServerEndpoints(IEndpointRouteBuilder builder)
     {

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -2,9 +2,12 @@
   <PropertyGroup>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
-    <PublishAot>!$([MSBuild]::ValueOrDefault('$(BuildingInsideVisualStudio)', 'false'))</PublishAot>
+    <PublishAot>true</PublishAot>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
     <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' == 'true' ">
+    <PublishAot>false</PublishAot>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LondonTravel.Skill\LondonTravel.Skill.csproj" />

--- a/test/LondonTravel.Skill.Tests/AlexaFunctionTests.cs
+++ b/test/LondonTravel.Skill.Tests/AlexaFunctionTests.cs
@@ -149,7 +149,7 @@ public class AlexaFunctionTests(ITestOutputHelper outputHelper) : FunctionTests(
     protected sealed class TestAlexaFunctionWithSecrets(
         SecretsManagerCache cache,
         HttpClientInterceptorOptions interceptor,
-        ITestOutputHelper? outputHelper) : TestAlexaFunction(interceptor, outputHelper)
+        ITestOutputHelper outputHelper) : TestAlexaFunction(interceptor, outputHelper)
     {
         protected override void Configure(ConfigurationBuilder builder)
         {
@@ -160,7 +160,7 @@ public class AlexaFunctionTests(ITestOutputHelper outputHelper) : FunctionTests(
         protected override void ConfigureServices(IServiceCollection services)
         {
             base.ConfigureServices(services);
-            services.AddLogging((builder) => builder.AddOpenTelemetry((r) => r.AddOtlpExporter()));
+            services.AddLogging((p) => p.AddOpenTelemetry((r) => r.AddOtlpExporter()));
         }
     }
 }

--- a/test/LondonTravel.Skill.Tests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.Tests/EndToEndTests.cs
@@ -210,7 +210,7 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
         // Arrange
         string json = JsonSerializer.Serialize(request, AppJsonSerializerContext.Default.SkillRequest);
 
-        using var server = new LambdaTestServer((services) => services.AddLogging((builder) => builder.AddXUnit(this)));
+        using var server = new LambdaTestServer((services) => services.AddLogging((builder) => builder.AddXUnit(OutputHelper)));
         using var cancellationTokenSource = new CancellationTokenSource();
 
         await server.StartAsync(cancellationTokenSource.Token);
@@ -251,11 +251,10 @@ public class EndToEndTests(ITestOutputHelper outputHelper) : FunctionTests(outpu
         return actual;
     }
 
-    private sealed class TestAlexaFunctionWithHttpRequests : TestSettingsAlexaFunction
+    private sealed class TestAlexaFunctionWithHttpRequests() : TestSettingsAlexaFunction(TestContext.Current.TestOutputHelper!)
     {
         protected override void ConfigureServices(IServiceCollection services)
         {
-            services.AddLogging((builder) => builder.AddConsole());
             services.AddSingleton<IHttpMessageHandlerBuilderFilter, HttpRequestInterceptionFilter>(
                 (_) =>
                 {


### PR DESCRIPTION
- Avoid deadlocks on the console in tests by ensuring there is either exactly one console logger, or by removing it completely and just using the xunit logger.
- Fix being unable to debug the AoT tests in Visual Studio.
