### PR TITLE
Microsoft Testing Platform preparation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ trim_trailing_whitespace = true
 spelling_exclusion_path = .\exclusion.dic
 spelling_languages = en-us
 
-[*.{config,csproj,json,props,ruleset,targets,vsconfig,yml}]
+[*.{config,csproj,json,props,ruleset,runsettings,targets,vsconfig,yml}]
 indent_size = 2
 
 [*.{sh}]

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ UpgradeLog*.XML
 *.DotSettings
 *.log
 *.nupkg
+!.packages/*.nupkg
 *.opensdf
 *.[Pp]ublish.xml
 *.publishproj

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,5 @@
 {
+  "files.associations": {
+    "*.runsettings": "xml"
+  }
 }


### PR DESCRIPTION
- Add EditorConfig and VS Code settings for `.runsettings`.
- Update .gitignore for local NuGet packages.
