### PR TITLE
Move .NET to D drive on Windows runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,14 @@ jobs:
 
     steps:
 
+    - name: Update Windows agent configuration
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        "DOTNET_INSTALL_DIR=D:\tools\dotnet" >> ${env:GITHUB_ENV}
+        "DOTNET_ROOT=D:\tools\dotnet" >> ${env:GITHUB_ENV}
+        "NUGET_PACKAGES=D:\.nuget\packages" >> ${env:GITHUB_ENV}
+
     - name: Setup arm64 support for native AoT
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
Speed up Windows builds by moving .NET from the C drive to the D drive.

See [_GitHub Actions Hosted Windows Runners, Slower-than-expected CI, and You_](https://chadgolden.com/blog/github-actions-hosted-windows-runners-slower-than-expected-ci-and-you).