### PR TITLE
Update to AWSSDK v4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <AssemblyIsCLSCompliant>false</AssemblyIsCLSCompliant>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)LondonTravel.Skill.ruleset</CodeAnalysisRuleSet>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.1" />
     <PackageVersion Include="Aspire.Hosting.AWS" Version="9.2.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.2.1" />
-    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="4.0.1" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="4.0.0.1" />
+    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="4.0.1.1" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="4.0.0.2" />
     <PackageVersion Include="AWSSDK.SecretsManager" Version="3.7.400.104" />
     <PackageVersion Include="AWSSDK.SecretsManager.Caching" Version="2.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.1" />
-    <PackageVersion Include="Aspire.Hosting.AWS" Version="9.1.9" />
+    <PackageVersion Include="Aspire.Hosting.AWS" Version="9.2.0" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.2.1" />
     <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="4.0.1" />
     <PackageVersion Include="AWSSDK.Lambda" Version="4.0.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,10 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.1" />
     <PackageVersion Include="Aspire.Hosting.AWS" Version="9.1.9" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.2.1" />
-    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="3.7.409.40" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.411.47" />
+    <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="4.0.1" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="4.0.0.1" />
     <PackageVersion Include="AWSSDK.SecretsManager" Version="3.7.400.104" />
-    <PackageVersion Include="AWSSDK.SecretsManager.Caching" Version="1.0.6" />
+    <PackageVersion Include="AWSSDK.SecretsManager.Caching" Version="2.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
@@ -40,11 +40,11 @@
     <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.11.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.11.0-beta.2" />
-    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.11.0-beta.2" />
+    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.5.2" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.5.2" />
     <PackageVersion Include="ReportGenerator" Version="5.4.6" />

--- a/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/CloudWatchLogsFixture.cs
@@ -294,7 +294,7 @@ public class CloudWatchLogsFixture(IMessageSink diagnosticMessageSink) : IAsyncL
         var entry = new LogEvent(name)
         {
             RequestId = requestId,
-            Timestamp = @event.Timestamp,
+            Timestamp = @event.Timestamp ?? default,
         };
 
         var builder = new StringBuilder()


### PR DESCRIPTION
Update to version 4 of the AWSSDKs.

~~Depends on AWS' support for .NET Aspire being updated for v4.~~
