### PR TITLE
Disable Aspire dependency check timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       ARCHIVE_NAME: alexa-london-travel
       ARTIFACT_NAME: lambda
+      ASPIRE_DEPENDENCY_CHECK_TIMEOUT: 0
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_GENERATE_ASPNET_CERTIFICATE: false
       DOTNET_NOLOGO: true


### PR DESCRIPTION
Try to avoid flaky tests on Windows while Aspire waits for Docker/Podman to be available.
