### PR TITLE
Add host.id

### DIFF
--- a/src/LondonTravel.Skill/SkillTelemetry.cs
+++ b/src/LondonTravel.Skill/SkillTelemetry.cs
@@ -18,6 +18,7 @@ internal static class SkillTelemetry
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceNamespace, ServiceVersion)
         .AddHostDetector()
+        .AddAttributes([new("host.id", Guid.NewGuid().ToString())])
         .AddOperatingSystemDetector()
         .AddProcessRuntimeDetector();
 

--- a/src/LondonTravel.Skill/SkillTelemetry.cs
+++ b/src/LondonTravel.Skill/SkillTelemetry.cs
@@ -17,8 +17,8 @@ internal static class SkillTelemetry
 
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceNamespace, ServiceVersion)
-        .AddHostDetector()
         .AddAttributes([new("host.id", Guid.NewGuid().ToString())])
+        .AddHostDetector()
         .AddOperatingSystemDetector()
         .AddProcessRuntimeDetector();
 


### PR DESCRIPTION
Add a manually created `host.id` for metrics in AWS Lambda as the host detector does not detect one on Amazon Linux 2023.
