### PR TITLE
Set DisableAwsXRayContextExtraction

### DIFF
--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -26,7 +26,7 @@ internal static class TelemetryExtensions
 
                     if (AlexaFunction.IsRunningInAwsLambda())
                     {
-                        builder.AddAWSLambdaConfigurations()
+                        builder.AddAWSLambdaConfigurations((p) => p.DisableAwsXRayContextExtraction = true)
                                .AddOtlpExporter();
                     }
                 });


### PR DESCRIPTION
Set `DisableAwsXRayContextExtraction=true` to fix missing root spans in the Lambda invocations.
