### PR TITLE
Fix deployed version number

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <PublishForAWSLambda>false</PublishForAWSLambda>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>3.0.$([MSBuild]::ValueOrDefault('$(GITHUB_RUN_NUMBER)', '0'))</VersionPrefix>
+    <VersionSuffix Condition=" '$(GitHubBranchName)' == 'main' "></VersionSuffix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(EnableReferenceTrimmer)' != 'false' and '$(GenerateDocumentationFile)' != 'true' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Do not include a version suffix when building from `main`.
