### PR TITLE
Use GITHUB_REF_NAME

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PublishForAWSLambda>false</PublishForAWSLambda>
-    <StabilizeVersion Condition=" '$(GitHubBranchName)' == 'main' ">true</StabilizeVersion>
+    <StabilizeVersion Condition=" '$(GITHUB_REF_NAME)' == 'main' ">true</StabilizeVersion>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>3.0.$([MSBuild]::ValueOrDefault('$(GITHUB_RUN_NUMBER)', '0'))</VersionPrefix>
   </PropertyGroup>


### PR DESCRIPTION
Property is set too early for `GitHubBranchName` to be available.
