### PR TITLE
Remove redundant code

### DIFF
--- a/src/LondonTravel.Skill/SkillTelemetry.cs
+++ b/src/LondonTravel.Skill/SkillTelemetry.cs
@@ -17,11 +17,7 @@ internal static class SkillTelemetry
 
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceNamespace, ServiceVersion)
-        .AddAttributes(
-            [
-                new("host.id", Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME") ?? Environment.MachineName),
-                new("service.instance.id", Guid.NewGuid().ToString()),
-            ])
+        .AddAttributes([new("host.id", Environment.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME") ?? Environment.MachineName)])
         .AddHostDetector()
         .AddOperatingSystemDetector()
         .AddProcessRuntimeDetector();


### PR DESCRIPTION
`AddService()` already adds `service.instance.id`.
