### PR TITLE
Remove metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
     needs: [ build ]
     uses: ./.github/workflows/deploy-app.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     secrets: inherit
@@ -189,7 +189,7 @@ jobs:
     needs: [ build, deploy-dev ]
     uses: ./.github/workflows/deploy-app.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     secrets: inherit

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -70,6 +70,7 @@ jobs:
       name: ${{ inputs.environment-name }}
 
     permissions:
+      contents: write
       id-token: write
       pull-requests: write
 
@@ -79,46 +80,29 @@ jobs:
     steps:
 
     - name: Create deployment annotation
-      id: annotate-deployment
-      if: ${{ vars.TELEMETRY_URL && vars.TELEMETRY_URL != '' }}
-      shell: pwsh
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
         APPLICATION_NAME: LondonTravel.Skill
         ENVIRONMENT_NAME: ${{ inputs.environment-name }}
-        TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
-        TELEMETRY_URL: ${{ vars.TELEMETRY_URL }}
-      run: |
-        $commitSha = ${env:GITHUB_SHA}.Substring(0, 7)
-        $commitUrl = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/commit/${env:GITHUB_SHA}"
-        $workflowUrl = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/actions/runs/${env:GITHUB_RUN_ID}"
-
-        $body = @{
-          tags = @(
-            "deployment",
-            "environment:${env:ENVIRONMENT_NAME}",
-            "service:${env:APPLICATION_NAME}"
-          );
-          text = "Deployed <a href='${workflowUrl}'>#${env:GITHUB_RUN_NUMBER}:${env:GITHUB_RUN_ATTEMPT}</a> with commit <a href='${commitUrl}'>${commitSha}</a>";
-          time = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds();
-        } | ConvertTo-Json
-
-        try {
-          $annotation = Invoke-RestMethod -Uri "${env:TELEMETRY_URL}/api/annotations" `
-            -Method Post `
-            -Headers @{
-              "Accept" = "application/json";
-              "Authorization" = "Bearer ${env:TELEMETRY_TOKEN}";
-              "Content-Type" = "application/json";
-            } `
-            -Body $body
-
-          $id = $annotation.id
-
-          Write-Output "Created deployment annotation ${id}"
-          "id=${id}" >> ${env:GITHUB_OUTPUT}
-        } catch {
-          Write-Output "::warning::Failed to create deployment annotation"
-        }
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          await github.rest.repos.createDispatchEvent({
+            owner,
+            repo,
+            event_type: 'deployment_started',
+            client_payload: {
+              application: process.env.APPLICATION_NAME,
+              environment: process.env.ENVIRONMENT_NAME,
+              repository: process.env.GITHUB_REPOSITORY,
+              runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+              runId: process.env.GITHUB_RUN_ID,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+              serverUrl: process.env.GITHUB_SERVER_URL,
+              sha: process.env.GITHUB_SHA,
+              timestamp: Date.now(),
+            }
+          });
 
     - name: Post deployment starting comment
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -258,31 +242,22 @@ jobs:
           });
 
     - name: Update deployment annotation
-      if: ${{ !cancelled() && steps.annotate-deployment.outputs.id != '' }}
-      shell: pwsh
-      env:
-        ANNOTATION_ID: ${{ steps.annotate-deployment.outputs.id }}
-        TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
-        TELEMETRY_URL: ${{ vars.TELEMETRY_URL }}
-      run: |
-        $body = @{
-          timeEnd = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds();
-        } | ConvertTo-Json
-
-        try {
-          Invoke-RestMethod -Uri "${env:TELEMETRY_URL}/api/annotations/${env:ANNOTATION_ID}" `
-            -Method Patch `
-            -Headers @{
-              "Accept" = "application/json";
-              "Authorization" = "Bearer ${env:TELEMETRY_TOKEN}";
-              "Content-Type" = "application/json";
-            } `
-            -Body $body | Out-Null
-
-          Write-Output "Updated deployment annotation ${env:ANNOTATION_ID}"
-        } catch {
-          Write-Output "::warning::Failed to update deployment annotation ${env:ANNOTATION_ID}"
-        }
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ !cancelled() }}
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          await github.rest.repos.createDispatchEvent({
+            owner,
+            repo,
+            event_type: 'deployment_completed',
+            client_payload: {
+              repository: process.env.GITHUB_REPOSITORY,
+              runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+              timestamp: Date.now(),
+            }
+          });
 
   test:
     needs: [ deploy ]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,7 +137,7 @@ jobs:
     needs: [ setup ]
     uses: ./.github/workflows/deploy-app.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     secrets: inherit

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />

--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Instrumentation.AWSLambda;
 using OpenTelemetry.Instrumentation.Http;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 namespace MartinCostello.LondonTravel.Skill.Extensions;
@@ -16,18 +15,6 @@ internal static class TelemetryExtensions
     {
         services.AddSingleton((_) => SkillTelemetry.ActivitySource);
         services.AddOpenTelemetry()
-                .WithMetrics((builder) =>
-                {
-                    builder.SetResourceBuilder(SkillTelemetry.ResourceBuilder)
-                           .AddHttpClientInstrumentation()
-                           .AddProcessInstrumentation()
-                           .AddMeter("System.Runtime");
-
-                    if (AlexaFunction.IsRunningInAwsLambda())
-                    {
-                        builder.AddOtlpExporter();
-                    }
-                })
                 .WithTracing((builder) =>
                 {
                     builder.SetResourceBuilder(SkillTelemetry.ResourceBuilder)

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -41,7 +41,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
     <PackageReference Include="OpenTelemetry.Resources.Host" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" />
     <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" />


### PR DESCRIPTION
- Metrics don't work in AWS Lambda functions.
- Use `repository_dispatch` for deployment annotations.
