### PR TITLE
Fix trace filtering

### DIFF
--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -67,7 +67,8 @@ internal static class TelemetryExtensions
     private static bool FilterHttpRequest(HttpRequestMessage message, ILogger logger)
     {
 #pragma warning disable CA1848
-        logger.LogInformation("Runtime API base address: {BaseAddress}", RuntimeApiBaseAddress);
+        logger.LogInformation("Raw Runtime API base address: {BaseAddress}", Environment.GetEnvironmentVariable("AWS_LAMBDA_RUNTIME_API"));
+        logger.LogInformation("Parsed Runtime API base address: {BaseAddress}", RuntimeApiBaseAddress);
         logger.LogInformation("Filtering HTTP request: {Method} {Uri}", message.Method, message.RequestUri);
 #pragma warning restore CA1848
 

--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AWSLambda;
 using OpenTelemetry.Instrumentation.Http;


### PR DESCRIPTION
Fix trace filtering for HTTP requests by using a parsing method that works for `{host}:{ip}` without a scheme, e.g. `127.0.0.1:9001`.
