### PR TITLE
Restore metrics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />

--- a/src/LondonTravel.Skill/AlexaFunction.cs
+++ b/src/LondonTravel.Skill/AlexaFunction.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Metrics;
 
 namespace MartinCostello.LondonTravel.Skill;
 
@@ -56,18 +57,25 @@ public class AlexaFunction : IAsyncDisposable, IDisposable
     /// Handles a request to the skill as an asynchronous operation.
     /// </summary>
     /// <param name="request">The skill request.</param>
-    /// <param name="context">The Lamda request context.</param>
+    /// <param name="context">The Lambda request context.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> representing the asynchronous operation to get the skill's response.
     /// </returns>
     public async Task<SkillResponse> HandlerAsync(SkillRequest request, ILambdaContext context)
     {
         EnsureInitialized();
-        return await OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaWrapper.TraceAsync(
+
+        var meterProvider = _serviceProvider.GetRequiredService<MeterProvider>();
+
+        var response = await OpenTelemetry.Instrumentation.AWSLambda.AWSLambdaWrapper.TraceAsync(
             _serviceProvider.GetRequiredService<OpenTelemetry.Trace.TracerProvider>(),
             HandlerCoreAsync,
             request,
             context);
+
+        meterProvider.ForceFlush();
+
+        return response;
     }
 
     /// <summary>

--- a/src/LondonTravel.Skill/LondonTravel.Skill.csproj
+++ b/src/LondonTravel.Skill/LondonTravel.Skill.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AWS" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
     <PackageReference Include="OpenTelemetry.Resources.Host" />
     <PackageReference Include="OpenTelemetry.Resources.OperatingSystem" />
     <PackageReference Include="OpenTelemetry.Resources.ProcessRuntime" />


### PR DESCRIPTION
Restore metrics usage with explicit flush and custom exporter settings to see if it makes it work (at the expense of the flush time).
