### PR TITLE
Add AWS instrumentation

### DIFF
--- a/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
+++ b/src/LondonTravel.Skill/Extensions/TelemetryExtensions.cs
@@ -37,6 +37,7 @@ internal static class TelemetryExtensions
             builder.WithMetrics((builder) =>
             {
                 builder.SetResourceBuilder(SkillTelemetry.ResourceBuilder)
+                       .AddAWSInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddProcessInstrumentation()
                        .AddMeter(SkillTelemetry.ServiceName)
@@ -48,6 +49,7 @@ internal static class TelemetryExtensions
                {
                    builder.SetResourceBuilder(SkillTelemetry.ResourceBuilder)
                           .AddSource(SkillTelemetry.ServiceName)
+                          .AddAWSInstrumentation()
                           .AddHttpClientInstrumentation();
 
                    if (isRunningInLambda)


### PR DESCRIPTION
Add AWS instrumentation for metrics and traces for AWSSDKs, such as for AWS Secrets Manager.

The dependency has been there for a long time (since #1020), but it wasn't activated.
