### PR TITLE
Extend benchmarks

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -80,3 +80,8 @@ if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
 }
 
 & $dotnet run --project $benchmarks --configuration "Release" -- $additionalArgs
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Benchmark run failed with exit code $LASTEXITCODE."
+    exit $LASTEXITCODE
+}

--- a/perf/LondonTravel.Skill.Benchmarks/AppServer.cs
+++ b/perf/LondonTravel.Skill.Benchmarks/AppServer.cs
@@ -73,8 +73,8 @@ internal sealed class AppServer(string httpServerUrl) : IAsyncDisposable
 
             var config = new Dictionary<string, string?>()
             {
-                ["AWS_ACCESS_KEY_ID"] = "Critical",
-                ["AWS_SECRET_ACCESS_KEY"] = "aws-access-key-id",
+                ["AWS_ACCESS_KEY_ID"] = "aws-access-key-id",
+                ["AWS_SECRET_ACCESS_KEY"] = "aws-secret-access-key",
                 ["Logging:LogLevel:Default"] = "Critical",
                 ["Skill:SkillId"] = "amzn1.ask.skill.49f13574-8134-4748-afeb-62ef1defffa6",
                 ["Skill:TflApplicationId"] = "tfl-application-id",

--- a/perf/LondonTravel.Skill.Benchmarks/AppServer.cs
+++ b/perf/LondonTravel.Skill.Benchmarks/AppServer.cs
@@ -27,8 +27,6 @@ internal sealed class AppServer(string httpServerUrl) : IAsyncDisposable
         {
             await app.StartAsync(_cts.Token);
 
-            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", "aws-access-key-id");
-            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", "aws-secret-access-key");
             Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL_SECRETS_MANAGER", httpServerUrl);
             Environment.SetEnvironmentVariable("Skill__SkillApiUrl", httpServerUrl);
             Environment.SetEnvironmentVariable("Skill__TflApiUrl", httpServerUrl);

--- a/perf/LondonTravel.Skill.Benchmarks/LondonTravel.Skill.Benchmarks.csproj
+++ b/perf/LondonTravel.Skill.Benchmarks/LondonTravel.Skill.Benchmarks.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\LondonTravel.Skill\LondonTravel.Skill.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\test\Shared\*.cs" Link="%(Filename)" />
     <EmbeddedResource Include="..\..\src\LondonTravel.Skill.AppHost\.aws-lambda-testtool\SavedRequests\LondonTravelSkill\*.json" LinkBase="Payloads" LogicalName="%(FileName)%(Extension)" />
   </ItemGroup>
   <ItemGroup>

--- a/perf/LondonTravel.Skill.Benchmarks/Program.cs
+++ b/perf/LondonTravel.Skill.Benchmarks/Program.cs
@@ -25,8 +25,11 @@ if (args.SequenceEqual(["--test"]))
     {
         await benchmark.StopServer();
     }
+
+    return 0;
 }
 else
 {
-    BenchmarkRunner.Run<AppBenchmarks>(args: args);
+    var summary = BenchmarkRunner.Run<AppBenchmarks>(args: args);
+    return summary.Reports.Any((p) => !p.Success) ? 1 : 0;
 }

--- a/perf/LondonTravel.Skill.Benchmarks/Program.cs
+++ b/perf/LondonTravel.Skill.Benchmarks/Program.cs
@@ -6,15 +6,18 @@ using MartinCostello.LondonTravel.Skill.Benchmarks;
 
 if (args.SequenceEqual(["--test"]))
 {
-    using var benchmark = new AppBenchmarks();
+    await using var benchmark = new AppBenchmarks();
     await benchmark.StartServer();
 
     try
     {
         _ = await benchmark.Cancel();
+        _ = await benchmark.Commute();
+        _ = await benchmark.Disruption();
         _ = await benchmark.Help();
         _ = await benchmark.Launch();
         _ = await benchmark.SessionEnded();
+        _ = await benchmark.Status();
         _ = await benchmark.Stop();
         _ = await benchmark.UnknownIntent();
     }

--- a/test/LondonTravel.Skill.AppHostTests/LambdaFunctionFixture.cs
+++ b/test/LondonTravel.Skill.AppHostTests/LambdaFunctionFixture.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using Amazon.Lambda;
 using Amazon.Runtime;
 using MartinCostello.Logging.XUnit;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -59,10 +58,10 @@ public sealed class LambdaFunctionFixture : IAsyncLifetime, ITestOutputHelperAcc
             throw new InvalidOperationException("The Lambda function has already been started.");
         }
 
-        _httpServer = new HttpServer(ConfigureServices, AddHttpServerEndpoints);
+        _httpServer = new(ConfigureServices);
         await _httpServer.StartAsync(cancellationToken);
 
-        _application = new LambdaFunctionApplication(_httpServer.ServerUrl, ConfigureServices);
+        _application = new(_httpServer.ServerUrl, ConfigureServices);
         await _application.StartAsync(cancellationToken);
     }
 
@@ -81,13 +80,6 @@ public sealed class LambdaFunctionFixture : IAsyncLifetime, ITestOutputHelperAcc
                    .AddXUnit(this)
                    .SetMinimumLevel(LogLevel.Warning);
         });
-
-    private void AddHttpServerEndpoints(IEndpointRouteBuilder builder)
-    {
-        SecretsManager.AddEndpoints(builder);
-        TflApi.AddEndpoints(builder);
-        UserPreferences.AddEndpoints(builder);
-    }
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed, this);
 

--- a/test/LondonTravel.Skill.AppHostTests/LondonTravel.Skill.AppHostTests.csproj
+++ b/test/LondonTravel.Skill.AppHostTests/LondonTravel.Skill.AppHostTests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\LondonTravel.Skill.Tests\CategoryAttribute.cs" Link="CategoryAttribute.cs" />
+    <Compile Include="..\Shared\*.cs" Link="%(Filename)" />
     <EmbeddedResource Include="..\..\src\LondonTravel.Skill.AppHost\.aws-lambda-testtool\SavedRequests\LondonTravelSkill\*.json" LinkBase="Payloads" LogicalName="Payload-%(Filename)" />
   </ItemGroup>
   <PropertyGroup>

--- a/test/Shared/SecretsManager.cs
+++ b/test/Shared/SecretsManager.cs
@@ -8,7 +8,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
-namespace MartinCostello.LondonTravel.Skill.AppHostTests;
+#pragma warning disable IDE0130
+namespace MartinCostello.LondonTravel.Skill;
 
 internal static class SecretsManager
 {

--- a/test/Shared/TflApi.cs
+++ b/test/Shared/TflApi.cs
@@ -6,7 +6,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 
-namespace MartinCostello.LondonTravel.Skill.AppHostTests;
+#pragma warning disable IDE0130
+namespace MartinCostello.LondonTravel.Skill;
 
 internal static class TflApi
 {

--- a/test/Shared/UserPreferences.cs
+++ b/test/Shared/UserPreferences.cs
@@ -6,7 +6,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
-namespace MartinCostello.LondonTravel.Skill.AppHostTests;
+#pragma warning disable IDE0130
+namespace MartinCostello.LondonTravel.Skill;
 
 internal static class UserPreferences
 {


### PR DESCRIPTION
- Fail the benchmarks if a non-zero exit code is returned.
- Move mock HTTP server to shared folder to re-use in benchmarks.
- Extend the benchmarks to use the mock HTTP server and benchmark the intents that access HTTP remote services.
