### PR TITLE
Extend code coverage

### DIFF
--- a/src/LondonTravel.Skill/CultureSwitcher.cs
+++ b/src/LondonTravel.Skill/CultureSwitcher.cs
@@ -51,6 +51,7 @@ internal sealed class CultureSwitcher : IDisposable
         return false;
     }
 
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     private sealed class NullDisposable : IDisposable
     {
         internal static readonly NullDisposable Instance = new();

--- a/src/LondonTravel.Skill/SkillMetrics.cs
+++ b/src/LondonTravel.Skill/SkillMetrics.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Metrics;
 
 namespace MartinCostello.LondonTravel.Skill;
 
-internal sealed class SkillMetrics
+public sealed class SkillMetrics : IDisposable
 {
     private readonly Meter _meter;
     private readonly Counter<long> _skillInvocationCounter;

--- a/test/LondonTravel.Skill.Tests/IConfigurationBuilderExtensionsTests.cs
+++ b/test/LondonTravel.Skill.Tests/IConfigurationBuilderExtensionsTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.LondonTravel.Skill.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+public static class IConfigurationBuilderExtensionsTests
+{
+    [Fact]
+    public static void AddSecretsManager_Adds_Configuration_Source()
+    {
+        // Arrange
+        var builder = new ConfigurationBuilder();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL_SECRETS_MANAGER", "http://aws.local");
+
+            // Act
+            builder.AddSecretsManager();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL_SECRETS_MANAGER", null);
+        }
+
+        // Assert
+        builder.Sources.Count.ShouldBe(1);
+        builder.Sources[0].GetType().Name.ShouldBe("SecretsManagerConfigurationSource");
+
+        // Act and Assert
+        Should.NotThrow(builder.Build);
+
+        // Act and Assert
+        Should.NotThrow(() =>
+        {
+            foreach (var source in builder.Sources)
+            {
+                if (source is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
+        });
+    }
+}

--- a/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
+++ b/test/LondonTravel.Skill.Tests/LondonTravel.Skill.Tests.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <Threshold>84</Threshold>
+    <Threshold>95,87,95</Threshold>
   </PropertyGroup>
   <ItemGroup>
     <CoverletExclude Include="$([MSBuild]::Escape('[Amazon.Lambda*]*'))" />

--- a/test/LondonTravel.Skill.Tests/MixedDateTimeConverterTests.cs
+++ b/test/LondonTravel.Skill.Tests/MixedDateTimeConverterTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using MartinCostello.LondonTravel.Skill.Models;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+#pragma warning disable JSON002
+
+public static class MixedDateTimeConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+    };
+
+    [Fact]
+    public static void Converter_Converts_Json_String()
+    {
+        // Arrange
+        string json =
+            """
+            {
+                "Value": "2023-10-01T12:00:00Z"
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Deserialize<Model>(json, Options);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Value.ShouldBe(new(2023, 10, 1, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public static void Converter_Converts_Json_Number()
+    {
+        // Arrange
+        string json =
+            """
+            {
+                "Value": 1753609472466
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Deserialize<Model>(json, Options);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Value.ShouldBe(new(2025, 07, 27, 09, 44, 32, 466, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public static void Converter_Throws_If_Unsupported_Kind()
+    {
+        // Arrange
+        string json =
+            """
+            {
+                "Value": true
+            }
+            """;
+
+        // Act and Assert
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Model>(json, Options));
+    }
+
+    private sealed class Model
+    {
+        [JsonConverter(typeof(MixedDateTimeConverter))]
+        public DateTime Value { get; set; }
+    }
+}

--- a/test/LondonTravel.Skill.Tests/SkillMetricsTests.cs
+++ b/test/LondonTravel.Skill.Tests/SkillMetricsTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Martin Costello, 2017. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MartinCostello.LondonTravel.Skill;
+
+public static class SkillMetricsTests
+{
+    [Fact]
+    public static void SkillMetrics_Initializes_With_Default_Values()
+    {
+        // Arrange
+        using var serviceProvider = new ServiceCollection()
+            .AddMetrics()
+            .BuildServiceProvider();
+
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        using var target = new SkillMetrics(meterFactory);
+
+        // Act and Assert
+        Should.NotThrow(() => target.SkillInvoked("Launch"));
+    }
+}


### PR DESCRIPTION
- Extend the code coverage further with some quick wins.
- Fixes SkillMetrics not implementing `IDisposable`.
