### PR TITLE
Add [JsonIgnore]

### DIFF
--- a/test/LondonTravel.Skill.EndToEndTests/PlatformExtensionEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformExtensionEvent.cs
@@ -8,5 +8,6 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformExtensionEvent : PlatformEvent
 {
+    [System.Text.Json.Serialization.JsonIgnore]
     public override string Type => PlatformEventType.Extension;
 }

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitEvent.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformInitEvent : PlatformEvent
 {
+    [JsonIgnore]
     public override string Type => PlatformEventType.Initialize;
 
     [JsonPropertyName("record")]

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitReportEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitReportEvent.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformInitReportEvent : PlatformEvent
 {
+    [JsonIgnore]
     public override string Type => PlatformEventType.InitializeReport;
 
     [JsonPropertyName("record")]

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformInitRuntimeDoneEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformInitRuntimeDoneEvent.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformInitRuntimeDoneEvent : PlatformEvent
 {
+    [JsonIgnore]
     public override string Type => PlatformEventType.InitializeRuntimeDone;
 
     [JsonPropertyName("record")]

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformReportEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformReportEvent.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformReportEvent : PlatformEvent
 {
+    [JsonIgnore]
     public override string Type => PlatformEventType.Report;
 
     [JsonPropertyName("record")]

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformRuntimeDoneEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformRuntimeDoneEvent.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformRuntimeDoneEvent : PlatformEvent
 {
+    [JsonIgnore]
     public override string Type => PlatformEventType.RuntimeDone;
 
     [JsonPropertyName("record")]

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformStartEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformStartEvent.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformStartEvent : PlatformEvent
 {
+    [JsonIgnore]
     public override string Type => PlatformEventType.Start;
 
     [JsonPropertyName("record")]

--- a/test/LondonTravel.Skill.EndToEndTests/PlatformTelemetrySubscriptionEvent.cs
+++ b/test/LondonTravel.Skill.EndToEndTests/PlatformTelemetrySubscriptionEvent.cs
@@ -8,5 +8,6 @@ namespace MartinCostello.LondonTravel.Skill.EndToEndTests;
 /// </summary>
 internal sealed class PlatformTelemetrySubscriptionEvent : PlatformEvent
 {
+    [System.Text.Json.Serialization.JsonIgnore]
     public override string Type => PlatformEventType.TelemetrySubscription;
 }


### PR DESCRIPTION
Add `[JsonIgnore]` to `Type` overrides as .NET 10 throws an exception rather than inheriting the base property's ignore.

Workaround for https://github.com/dotnet/runtime/issues/73255.

