### PR TITLE
Avoid UriFormatException

### DIFF
--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -318,7 +318,7 @@ public sealed class EndToEndTests
         timeout.CancelAfter(TimeSpan.FromSeconds(2));
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext.CancellationTokenSource.Token,
+            TestContext?.CancellationTokenSource?.Token ?? default,
             timeout.Token);
 
         await server.StartAsync(linked.Token);


### PR DESCRIPTION
- Try to avoid `UriFormatException` by ensuring the server is disposed before another test runs, even if the test times out.
- Increase native AoT test timeout to 20s.
- Avoid competing environment variable assignments by disabling native AoT test parallelism.
