### PR TITLE
Add timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,6 @@ jobs:
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         flags: ${{ matrix.os-name }}
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
@@ -100,7 +99,6 @@ jobs:
       with:
         flags: ${{ matrix.os-name }}
         report_type: test_results
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Publish artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   analysis:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     permissions:
       actions: read
@@ -58,6 +59,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs: [ analysis ]
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
     - name: Harden runner

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,7 @@ permissions: {}
 jobs:
   dependency-review:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     permissions:
       contents: read

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -60,8 +60,9 @@ permissions: {}
 jobs:
 
   deploy:
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: ubuntu-24.04
     concurrency: ${{ inputs.environment-name }}_environment
+    timeout-minutes: 5
 
     env:
       ARCHIVE_NAME: ${{ inputs.archive-name }}
@@ -268,8 +269,9 @@ jobs:
 
   test:
     needs: [ deploy ]
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: ubuntu-24.04
     concurrency: ${{ inputs.environment-name }}_environment
+    timeout-minutes: 5
 
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   setup:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     if: |
       github.event.issue.pull_request != '' &&
       github.event.repository.fork == false &&

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     permissions:
       actions: read


### PR DESCRIPTION
- Add a timeout to all GitHub Actions jobs.
- Remove the `CODECOV_TOKEN` secret.
