### PR TITLE
Use TestContext token in E2E tests

### DIFF
--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -27,7 +27,7 @@ public sealed class EndToEndTests
     // shared process-wide state (such as AWS_LAMBDA_RUNTIME_API) set by LambdaTestServer.
     private static readonly SemaphoreSlim Semaphore = new(1, 1);
 
-    public TestContext? TestContext { get; set; }
+    public TestContext TestContext { get; set; }
 
     private HttpClientInterceptorOptions Interceptor { get; } = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
 
@@ -306,14 +306,14 @@ public sealed class EndToEndTests
 
     private async Task<SkillResponse> ProcessRequestAsync(SkillRequest request)
     {
-        // Arrange
-        using var cts = new CancellationTokenSource(TimeoutMilliseconds);
+        // The [Timeout] attribute surfaces the test timeout through TestContext.CancellationToken.
+        var cancellationToken = TestContext.CancellationToken;
 
-        await Semaphore.WaitAsync(cts.Token);
+        await Semaphore.WaitAsync(cancellationToken);
 
         try
         {
-            return await ProcessRequestCoreAsync(request, cts.Token);
+            return await ProcessRequestCoreAsync(request, cancellationToken);
         }
         finally
         {
@@ -337,7 +337,6 @@ public sealed class EndToEndTests
         using var processingTimeout = new CancellationTokenSource();
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext?.CancellationToken ?? default,
             cancellationToken,
             processingTimeout.Token);
 


### PR DESCRIPTION
Remove the redundant `CancellationTokenSource` in `ProcessRequestAsync` and use the token surfaced by the `[Timeout]` attribute via `TestContext.CancellationToken` instead.

The custom CTS duplicated the 15s bound already enforced by `[Timeout(TimeoutMilliseconds, CooperativeCancellation = true)]`, and using the framework token also enables immediate cooperative cancellation. The tighter 10s `processingTimeout` for actual request processing is unchanged.