### PR TITLE
Enable MSTest reflection-free mode for Native AOT tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />

--- a/global.json
+++ b/global.json
@@ -11,7 +11,7 @@
   },
   "msbuild-sdks": {
     "Aspire.AppHost.Sdk": "13.4.6",
-    "MSTest.Sdk": "4.2.3"
+    "MSTest.Sdk": "4.3.0"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -1,7 +1,16 @@
 <Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <!-- Use the reflection-free MSTest source generator so the adapter invokes test members
+         (including the TestContext property setter) through generated delegates instead of
+         runtime reflection, which is not populated under Native AOT. -->
+    <MSTestSourceGenMode>ReflectionFree</MSTestSourceGenMode>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
+    <!-- ReflectionFree mode makes MSTest.TestAdapter's runtime hook paths reachable, which pull in
+         trim/AOT-unsafe code from Microsoft.TestPlatform.ObjectModel and System.Private.DataContractSerialization
+         (IL2026/IL2057/IL3050) plus an IL2072 from MSTest's own generated registration. These are outside our
+         control; testfx's own Native AOT acceptance tests tolerate them by not treating warnings as errors. -->
+    <NoWarn>$(NoWarn);IL2026;IL2057;IL2072;IL3050</NoWarn>
     <PublishAot>true</PublishAot>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>


### PR DESCRIPTION
Replicates the version bumps from #2407 (MSTest monorepo) and additionally opts the Native AOT test project into MSTest's reflection-free source generator to fix the `NullReferenceException` seen in Native AOT runs (e.g. #2408).

## Changes

- Bump `MSTest.Sdk` `4.2.3` → `4.3.0` (`global.json`).
- Bump `Microsoft.Testing.Extensions.HangDump` `2.3.0` → `2.3.1` (`Directory.Packages.props`).
- Set `<MSTestSourceGenMode>ReflectionFree</MSTestSourceGenMode>` on `LondonTravel.Skill.NativeAotTests`.

## Why

The default source-gen (`Rooting`) mode only roots types + pre-resolves test methods; attribute reads, constructor invocation and **property reflection still fall back to runtime reflection** ([testfx design doc](https://github.com/microsoft/testfx/blob/v4.3.0/docs/source-generator/design.md)). Under Native AOT that fallback does not populate the `TestContext` property, so tests that read `TestContext.CancellationToken` hit an NRE.

Reflection-free mode (new in MSTest 4.3.0, [#8586](https://github.com/microsoft/testfx/pull/8586)) additionally emits delegate-based invokers for members — including the `TestContext` setter — so it is populated without reflection.

## About the `NoWarn` suppressions

Enabling reflection-free mode makes `MSTest.TestAdapter`'s runtime hook paths reachable, which pull in trim/AOT-unsafe code from `Microsoft.TestPlatform.ObjectModel` and `System.Private.DataContractSerialization` (IL2026/IL2057/IL3050), plus an IL2072 from MSTest's own generated registration. These are outside our control. testfx's own [`NativeAotTests`](https://github.com/microsoft/testfx/blob/v4.3.0/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs) acceptance test tolerates the exact same warnings by building with `warnAsError: false`; because this repo treats warnings as errors, they are suppressed via `NoWarn` instead.

> Verified locally up to the ILC trim/AOT analysis stage; native linking + the test run are left to CI (local Windows env lacks the MSVC linker toolchain).
