### PR TITLE
Validate MSTest reflection-free Native AOT tests on 4.4 preview (no IL suppression)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,8 +33,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry" Version="10.8.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0-preview.26366.6" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0-preview.26367.5" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,7 @@
     <packageSource key="test-tools">
       <package pattern="MSTest*" />
       <package pattern="Microsoft.Testing.*" />
-      <package pattern="Microsoft.CodeCoverage*" />
+      <package pattern="Microsoft.CodeCoverage.MSBuild" />
       <package pattern="dotnet-coverage" />
     </packageSource>
   </packageSourceMapping>

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,10 +3,17 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="NuGet">
       <package pattern="*" />
+    </packageSource>
+    <packageSource key="test-tools">
+      <package pattern="MSTest*" />
+      <package pattern="Microsoft.Testing.*" />
+      <package pattern="Microsoft.CodeCoverage*" />
+      <package pattern="dotnet-coverage" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/global.json
+++ b/global.json
@@ -10,7 +10,7 @@
   },
   "msbuild-sdks": {
     "Aspire.AppHost.Sdk": "13.4.6",
-    "MSTest.Sdk": "4.3.2"
+    "MSTest.Sdk": "4.4.0-preview.26367.5"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <!-- Use the reflection-free MSTest source generator so the adapter invokes test members
+         (including the TestContext property setter) through generated delegates instead of
+         runtime reflection, which is not populated under Native AOT. -->
+    <MSTestSourceGenMode>ReflectionFree</MSTestSourceGenMode>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
     <PublishAot>true</PublishAot>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>


### PR DESCRIPTION
Validates the now-merged testfx fix [microsoft/testfx#9941](https://github.com/microsoft/testfx/pull/9941) end-to-end by upgrading to the latest MSTest **4.4 preview** and **removing the `IL2026` warning suppression** that the earlier 4.3.0 attempt (#2411) needed.

## What this does

- `MSTest.Sdk` → `4.4.0-preview.26367.5` (published 2026-07-17, **after** #9941 merged on 2026-07-15, so it includes the fix)
- `Microsoft.Testing.Extensions.HangDump` → `2.4.0-preview.26367.5`
- `Microsoft.Testing.Extensions.CodeCoverage` → `18.10.0-preview.26366.6` (the version the 4.4 SDK expects)
- Enables `<MSTestSourceGenMode>ReflectionFree</MSTestSourceGenMode>` on `LondonTravel.Skill.NativeAotTests`
- **Adds no `IL*` `NoWarn`** — the `NoWarn` line is unchanged from the repo default

## Why it matters

Enabling reflection-free mode fixes a `NullReferenceException` on `TestContext.CancellationToken` under Native AOT (the adapter now invokes the `TestContext` setter via a generated delegate instead of unavailable runtime reflection).

On earlier MSTest previews this surfaced one remaining MSTest-owned trim/AOT warning — `IL2026` from `TypeCache.ProviderDiscovery` (`Assembly.GetReferencedAssemblies` in `[AssemblyFixtureProvider]` discovery) — which #2411 had to suppress. testfx#9941 fixed that at the source (discovery is skipped when dynamic code is unsupported), so the suppression is no longer needed. **This PR proves it: the build is warning-clean without it.**

## Validation

`dotnet publish test/LondonTravel.Skill.NativeAotTests/... -c Release` locally reaches **"Generating native code"** with:
- **Zero** `IL20xx`/`IL30xx` warnings
- No `MSTEST0072`

(The final native *link* step fails on this Windows box due to a missing MSVC linker on `PATH` — purely environmental; CI links and runs the tests.)

## Notes

- These are **preview** packages from the dnceng public `test-tools` feed (added to `NuGet.config` with source mapping), so this PR is intended as **validation** rather than to merge as-is until MSTest 4.4 ships stable.
- A benign `NU1506` (duplicate `PackageVersion` for CodeCoverage) is emitted because the 4.4 SDK auto-injects a CodeCoverage `PackageVersion` that coexists with the repo's central pin (kept because two non-`MSTest.Sdk` test projects reference the package). It's a NuGet restore warning that does not block the build.
- Related: #2411 (the 4.3.0 attempt with the suppression), microsoft/testfx#9941 (the source fix).
