### PR TITLE
Fix NU1901 warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <GlobalPackageReference Include="ReferenceTrimmer" Version="3.5.7" />
   </ItemGroup>
   <ItemGroup>
+    <PackageVersion Include="Amazon.CDK.Lib" Version="2.262.1" />
     <PackageVersion Include="Amazon.Lambda.Core" Version="3.2.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.1.2" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />


### PR DESCRIPTION
Update Amazon.CDK.Lib to the latest version to resolve GHSA-464c-974j-9xm6.
