### PR TITLE
Enable reflection-free MSTest source generator

### DIFF
--- a/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
+++ b/test/LondonTravel.Skill.NativeAotTests/EndToEndTests.cs
@@ -27,7 +27,7 @@ public sealed class EndToEndTests
     // shared process-wide state (such as AWS_LAMBDA_RUNTIME_API) set by LambdaTestServer.
     private static readonly SemaphoreSlim Semaphore = new(1, 1);
 
-    public TestContext? TestContext { get; set; }
+    public TestContext TestContext { get; set; }
 
     private HttpClientInterceptorOptions Interceptor { get; } = new HttpClientInterceptorOptions().ThrowsOnMissingRegistration();
 
@@ -307,13 +307,13 @@ public sealed class EndToEndTests
     private async Task<SkillResponse> ProcessRequestAsync(SkillRequest request)
     {
         // Arrange
-        using var cts = new CancellationTokenSource(TimeoutMilliseconds);
+        var cancellationToken = TestContext.CancellationToken;
 
-        await Semaphore.WaitAsync(cts.Token);
+        await Semaphore.WaitAsync(cancellationToken);
 
         try
         {
-            return await ProcessRequestCoreAsync(request, cts.Token);
+            return await ProcessRequestCoreAsync(request, cancellationToken);
         }
         finally
         {
@@ -337,7 +337,6 @@ public sealed class EndToEndTests
         using var processingTimeout = new CancellationTokenSource();
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext?.CancellationToken ?? default,
             cancellationToken,
             processingTimeout.Token);
 

--- a/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
+++ b/test/LondonTravel.Skill.NativeAotTests/LondonTravel.Skill.NativeAotTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <MSTestSourceGenMode>ReflectionFree</MSTestSourceGenMode>
     <NoWarn>$(NoWarn);CA1062;CA1707;CA2007;CA2234;SA1600</NoWarn>
     <PublishAot>true</PublishAot>
     <RootNamespace>MartinCostello.LondonTravel.Skill</RootNamespace>


### PR DESCRIPTION
Supersedes #2408 and #2429.
